### PR TITLE
Adds test to check client cert auth in conjunction with mqtt

### DIFF
--- a/package.mk
+++ b/package.mk
@@ -4,13 +4,19 @@ WITH_BROKER_TEST_SCRIPTS:=$(PACKAGE_DIR)/test/test.sh
 WITH_BROKER_TEST_CONFIG:=$(PACKAGE_DIR)/test/ebin/test
 WITH_BROKER_SETUP_SCRIPTS:=$(PACKAGE_DIR)/test/setup-rabbit-test.sh
 
+ifndef RABBITMQ_MQTT_SSLTEST_ONLY
+  WITH_BROKER_TEST_CONFIG_INPUT:=test.config
+else
+  WITH_BROKER_TEST_CONFIG_INPUT:=test-client-cert-ssl-only.config
+endif
+
 define package_rules
 
 $(PACKAGE_DIR)+pre-test::
 	rm -rf $(PACKAGE_DIR)/test/certs
 	mkdir $(PACKAGE_DIR)/test/certs
 	mkdir -p $(PACKAGE_DIR)/test/ebin
-	sed -e "s|%%CERTS_DIR%%|$(abspath $(PACKAGE_DIR))/test/certs|g" < $(PACKAGE_DIR)/test/src/test.config > $(PACKAGE_DIR)/test/ebin/test.config
+	sed -e "s|%%CERTS_DIR%%|$(abspath $(PACKAGE_DIR))/test/certs|g" < $(PACKAGE_DIR)/test/src/$(WITH_BROKER_TEST_CONFIG_INPUT) > $(PACKAGE_DIR)/test/ebin/test.config
 	make -C $(PACKAGE_DIR)/../rabbitmq-test/certs all PASSWORD=bunnychow DIR=$(abspath $(PACKAGE_DIR))/test/certs
 
 $(PACKAGE_DIR)+clean::

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,7 +22,11 @@ endef
 
 .PHONY: test
 test: build_java_amqp
+ifndef RABBITMQ_MQTT_SSLTEST_ONLY
 	ant test -Dhostname=$(HOSTNAME)
+else
+	ant test-ssl -Dhostname=$(HOSTNAME)
+endif
 
 clean:
 	ant clean

--- a/test/src/test-client-cert-ssl-only.config
+++ b/test/src/test-client-cert-ssl-only.config
@@ -1,0 +1,16 @@
+[{rabbitmq_mqtt, [
+   {ssl_cert_login,   true},
+   {allow_anonymous,  true},
+   {tcp_listeners,    [1883]},
+   {ssl_listeners,    [8883]}
+   ]},
+ {rabbit, [{ssl_options, [{cacertfile,"%%CERTS_DIR%%/testca/cacert.pem"},
+                          {certfile,"%%CERTS_DIR%%/server/cert.pem"},
+                          {keyfile,"%%CERTS_DIR%%/server/key.pem"},
+                          {verify,verify_peer},
+                          {fail_if_no_peer_cert,true}
+                         ]}
+           ,{auth_mechanisms, ['EXTERNAL']}
+          ]}
+].
+


### PR DESCRIPTION
Due to alternate server configuration this test needs to be explicitly
requested by setting the following command-line parameter RABBITMQ_MQTT_SSLTEST_ONLY leaving the current non-SSL and SSL tests untouched.

$ cd rabbitmq-mqtt
$ export RABBITMQ_MQTT_SSLTEST_ONLY=1
$ make test

Github issue: https://github.com/rabbitmq/rabbitmq-mqtt/issues/19