### PR TITLE
Check authorization at MQTT topic level

### DIFF
--- a/include/rabbit_mqtt.hrl
+++ b/include/rabbit_mqtt.hrl
@@ -45,11 +45,11 @@
                       %% Retained messages handler. See rabbit_mqtt_retainer_sup
                       %% and rabbit_mqtt_retainer.
                       retainer_pid,
-                      auth_state }).
+                      auth_state}).
 
--record(auth_state, { username,
-                      user,
-                      vhost }).
+-record(auth_state, {username,
+                     user,
+                     vhost}).
 
 %% does not include vhost: it is used in
 %% the table name

--- a/include/rabbit_mqtt.hrl
+++ b/include/rabbit_mqtt.hrl
@@ -44,7 +44,12 @@
                       ssl_login_name,
                       %% Retained messages handler. See rabbit_mqtt_retainer_sup
                       %% and rabbit_mqtt_retainer.
-                      retainer_pid}).
+                      retainer_pid,
+                      auth_state }).
+
+-record(auth_state, { username,
+                      user,
+                      vhost }).
 
 %% does not include vhost: it is used in
 %% the table name

--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -461,8 +461,8 @@ creds(User, Pass, SSLLoginName) ->
         _ ->
             case {Pass =/= undefined, is_binary(DefaultPass), Anon =:= true, SSLLoginName == U} of
                  {true,  _,    _,    _} -> {U, list_to_binary(Pass)};
-                 {false, _,    _,    _} -> {U, none};
                  {false, true, true, _} -> {U, DefaultPass};
+                 {false, _,    _,    _} -> {U, none};
                  _                      -> {U, none}
             end
     end.
@@ -604,16 +604,16 @@ close_connection(PState = #proc_state{ connection = Connection,
 check_publish_or_die(TopicName, Fn, PState) ->
   case check_topic_access(TopicName, write, PState) of
     ok -> apply(Fn, []);
-    Other -> {err, unauthorized, PState}
+    _ -> {err, unauthorized, PState}
   end.
 
-check_subscribe_or_die([], Fn, PState) ->
+check_subscribe_or_die([], Fn, _) ->
   apply(Fn, []);
 
 check_subscribe_or_die([#mqtt_topic{ name = TopicName } | Topics], Fn, PState) ->
   case check_topic_access(TopicName, read, PState) of
-    ok -> apply(Fn, []);
-    Other -> {err, unauthorized, PState}
+    ok -> check_subscribe_or_die(Topics, Fn, PState);
+    _ -> {err, unauthorized, PState}
   end.
 
 check_topic_access(TopicName, Access,

--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -461,8 +461,8 @@ creds(User, Pass, SSLLoginName) ->
         _ ->
             case {Pass =/= undefined, is_binary(DefaultPass), Anon =:= true, SSLLoginName == U} of
                  {true,  _,    _,    _} -> {U, list_to_binary(Pass)};
-                 {false, true, true, _} -> {U, DefaultPass};
                  {false, _,    _,    _} -> {U, none};
+                 {false, true, true, _} -> {U, DefaultPass};
                  _                      -> {U, none}
             end
     end.

--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -28,8 +28,6 @@
 -define(FRAME_TYPE(Frame, Type),
         Frame = #mqtt_frame{ fixed = #mqtt_frame_fixed{ type = Type }}).
 
--define(MQTT_TOPIC_RESOURCE_KIND, mqtt_topic).
-
 initial_state(Socket,SSLLoginName) ->
     #proc_state{ unacked_pubs  = gb_trees:empty(),
                  awaiting_ack  = gb_trees:empty(),
@@ -623,6 +621,6 @@ check_topic_access(TopicName, Access,
                       auth_state = #auth_state{ user = User,
                                                 vhost = VHost }}) ->
   Resource = #resource{ virtual_host = VHost,
-                        kind = ?MQTT_TOPIC_RESOURCE_KIND,
+                        kind = topic,
                         name = TopicName },
   rabbit_access_control:check_resource_access(User, Resource, Access).

--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -97,7 +97,7 @@ process_request(?CONNECT,
                                                        connection = Conn,
                                                        client_id  = ClientId,
                                                        retainer_pid = RetainerPid,
-                                                       auth_state = AState })};
+                                                       auth_state = AState})};
                             ConnAck ->
                                 {ConnAck, PState}
                         end
@@ -417,7 +417,7 @@ process_login(UserBin, PassBin, ProtoVersion,
                   {?CONNACK_ACCEPT, Connection, VHost, #auth_state{
                                                          user = User,
                                                          username = UsernameBin,
-                                                         vhost = VHost }};
+                                                         vhost = VHost}};
                 not_allowed -> amqp_connection:close(Connection),
                                rabbit_log:warning(
                                  "MQTT login failed for ~p access_refused "
@@ -610,7 +610,7 @@ check_publish_or_die(TopicName, Fn, PState) ->
 check_subscribe_or_die([], Fn, _) ->
   Fn();
 
-check_subscribe_or_die([#mqtt_topic{ name = TopicName } | Topics], Fn, PState) ->
+check_subscribe_or_die([#mqtt_topic{name = TopicName} | Topics], Fn, PState) ->
   case check_topic_access(TopicName, read, PState) of
     ok -> check_subscribe_or_die(Topics, Fn, PState);
     _ -> {err, unauthorized, PState}
@@ -618,9 +618,9 @@ check_subscribe_or_die([#mqtt_topic{ name = TopicName } | Topics], Fn, PState) -
 
 check_topic_access(TopicName, Access,
                    #proc_state{
-                      auth_state = #auth_state{ user = User,
-                                                vhost = VHost }}) ->
-  Resource = #resource{ virtual_host = VHost,
-                        kind = topic,
-                        name = TopicName },
+                      auth_state = #auth_state{user = User,
+                                               vhost = VHost}}) ->
+  Resource = #resource{virtual_host = VHost,
+                       kind = topic,
+                       name = TopicName},
   rabbit_access_control:check_resource_access(User, Resource, Access).

--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -601,18 +601,18 @@ close_connection(PState = #proc_state{ connection = Connection,
 % was no auth error, but here we are closing the connection with an error. This
 % is what happens anyway if there is an authorization failure at the AMQP level.
 
-check_publish_or_die(TopicName, K, PState) ->
+check_publish_or_die(TopicName, Fn, PState) ->
   case check_topic_access(TopicName, write, PState) of
-    ok -> apply(K, []);
+    ok -> apply(Fn, []);
     Other -> {err, unauthorized, PState}
   end.
 
-check_subscribe_or_die([], K, PState) ->
-  apply(K, []);
+check_subscribe_or_die([], Fn, PState) ->
+  apply(Fn, []);
 
-check_subscribe_or_die([#mqtt_topic{ name = TopicName } | Topics], K, PState) ->
+check_subscribe_or_die([#mqtt_topic{ name = TopicName } | Topics], Fn, PState) ->
   case check_topic_access(TopicName, read, PState) of
-    ok -> apply(K, []);
+    ok -> apply(Fn, []);
     Other -> {err, unauthorized, PState}
   end.
 

--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -603,12 +603,12 @@ close_connection(PState = #proc_state{ connection = Connection,
 
 check_publish_or_die(TopicName, Fn, PState) ->
   case check_topic_access(TopicName, write, PState) of
-    ok -> apply(Fn, []);
+    ok -> Fn();
     _ -> {err, unauthorized, PState}
   end.
 
 check_subscribe_or_die([], Fn, _) ->
-  apply(Fn, []);
+  Fn();
 
 check_subscribe_or_die([#mqtt_topic{ name = TopicName } | Topics], Fn, PState) ->
   case check_topic_access(TopicName, read, PState) of

--- a/src/rabbit_mqtt_vhost_event_handler.erl
+++ b/src/rabbit_mqtt_vhost_event_handler.erl
@@ -33,7 +33,7 @@ handle_event({event, vhost_deleted, Info, _, _}, State) ->
   Name = pget(name, Info),
   rabbit_mqtt_retainer_sup:delete_child(Name),
   {ok, State};
-handle_event(Event, State) ->
+handle_event(_Event, State) ->
   {ok, State}.
 
 handle_call(_Request, State) ->


### PR DESCRIPTION
On `master` we only check authorization indirectly, at the level of the AMQP objects created behind the scenes. This PR adds explicit authorization checks at the level of MQTT topics.

This is done by calling `rabbit_access_control:check_resource_access` using the new resource kind of `mqtt_topic`. This works fine with  the `internal` and `ldap` auth backends, though it is possible third-party auth backends only expects kinds `exchange` and `queue`. With that in mind, I am considering putting the new authorization checks behind a configuration flag which defaults to off. I'll wait for some feedback before doing so, though.