### PR TITLE
Handle resource alarms messages in MQTT reader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ PROJECT = rabbitmq_mqtt
 
 DEPS = amqp_client
 
-TEST_DEPS = rabbitmq_test rabbitmq_java_client
+TEST_DEPS = rabbitmq_test rabbitmq_java_client emqttc
+
+dep_emqttc = git https://github.com/emqtt/emqttc.git master
 
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
@@ -26,6 +28,7 @@ WITH_BROKER_TEST_ENVVARS := \
 WITH_BROKER_TEST_SCRIPTS := $(CURDIR)/test/test.sh
 WITH_BROKER_SETUP_SCRIPTS := $(CURDIR)/test/setup-rabbit-test.sh
 
+WITH_BROKER_TEST_COMMANDS := eunit:test(rabbit_mqtt_reader)
 STANDALONE_TEST_COMMANDS := eunit:test(rabbit_mqtt_util)
 
 pre-standalone-tests:: test-tmpdir test-dist

--- a/src/rabbit_mqtt_reader.erl
+++ b/src/rabbit_mqtt_reader.erl
@@ -45,7 +45,7 @@ start_link(KeepaliveSup, Ref, Sock) ->
 
     {ok, Pid}.
 
-conserve_resources(Pid, _, Conserve) ->
+conserve_resources(Pid, _, {_, Conserve, _}) ->
     Pid ! {conserve_resources, Conserve},
     ok.
 

--- a/test/src/rabbit_mqtt_reader_tests.erl
+++ b/test/src/rabbit_mqtt_reader_tests.erl
@@ -1,0 +1,57 @@
+-module(rabbit_mqtt_reader_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+block_test_() ->
+    {foreach,
+    fun() ->
+        {ok, C} = emqttc:start_link([{host, "localhost"}, 
+                                 {client_id, <<"simpleClient">>}, 
+                                 {proto_ver, 3}, 
+                                 {logger, info}, 
+                                 {puback_timeout, 1}]),
+        emqttc:subscribe(C, <<"TopicA">>, qos0),
+        emqttc:publish(C, <<"TopicA">>, <<"Payload">>),
+        
+        %% Client is tricky. There is no way to tell if we are connected except
+        %% publishing and receiving
+        skip_publishes(<<"TopicA">>, [<<"Payload">>]),
+        emqttc:unsubscribe(C, [<<"TopicA">>]),
+        C
+    end,
+    fun(C) ->
+        vm_memory_monitor:set_vm_memory_high_watermark(0.4),
+        rabbit_alarm:clear_alarm({resource_limit, memory, node()}),
+        emqttc:disconnect(C)
+    end,
+    [
+    fun(C) ->
+        fun() ->
+        %% Not blocked
+        {ok, _} = emqttc:sync_publish(C, <<"Topic1">>, <<"Payload1">>, 
+                                      [{qos, 1}]),
+
+        vm_memory_monitor:set_vm_memory_high_watermark(0.00000001),
+        rabbit_alarm:set_alarm({{resource_limit, memory, node()}, []}),
+
+        %% Let it block
+        timer:sleep(100),
+        %% Blocked, but still will publish
+        {ok, _} = emqttc:sync_publish(C, <<"Topic1">>, <<"Still not blocked">>, 
+                                      [{qos, 1}]),
+
+        %% Blocked
+        {error, ack_timeout} = emqttc:sync_publish(C, <<"Topic1">>, 
+                                                   <<"Blocked">>, [{qos, 1}])
+        end
+    end
+    ]}.
+
+skip_publishes(Topic, []) -> ok;
+skip_publishes(Topic, [Payload|Rest]) ->
+    receive
+        {publish, Topic, Payload} -> skip_publishes(Topic, Rest)
+        after 100 -> 
+            throw({publish_not_delivered, Payload})
+    end.


### PR DESCRIPTION
Fixes #62

It's just a quick fix, because as you can see in tests, publish sent after alarm and block are being processed (Still not blocked payload). Which means that blocking is not correct.