### PR TITLE
Emit stats unconditionally

### DIFF
--- a/src/rabbit_mqtt_reader.erl
+++ b/src/rabbit_mqtt_reader.erl
@@ -356,15 +356,7 @@ emit_stats(State=#state{socket=Sock, connection_state=ConnState, connection=Conn
     Infos = [{pid, Conn}, {state, ConnState}|SockInfos],
     rabbit_event:notify(connection_stats, Infos),
     State1 = rabbit_event:reset_stats_timer(State, #state.stats_timer),
-    %% If we emit an event which looks like we are in flow control, it's not a
-    %% good idea for it to be our last even if we go idle. Keep emitting
-    %% events, either we stay busy or we drop out of flow control.
-    case ConnState of
-        flow -> ensure_stats_timer(State1);
-        _    -> State1
-    end.
+    ensure_stats_timer(State1).
 
-ensure_stats_timer(State = #state{connection_state = running}) ->
-    rabbit_event:ensure_stats_timer(State, #state.stats_timer, emit_stats);
-ensure_stats_timer(State) ->
-    State.
+ensure_stats_timer(State = #state{}) ->
+    rabbit_event:ensure_stats_timer(State, #state.stats_timer, emit_stats).


### PR DESCRIPTION
...of connection (flow control) state.

This makes it much easier to reason about flow control
state when looking at the management UI or monitoring tools
that poll HTTP API.
Now that rabbitmq/rabbitmq-management#41 is merged, there are
few arguments against always emitting stats.

Fixes #71.