### PR TITLE
Use the new -spec format

### DIFF
--- a/include/rabbit_mqtt_frame.hrl
+++ b/include/rabbit_mqtt_frame.hrl
@@ -48,21 +48,8 @@
 -define(QOS_1, 1).
 -define(QOS_2, 2).
 
--ifdef(use_specs).
-
 %% TODO
--type(message_id :: any()).
-
--type(mqtt_msg() :: #mqtt_msg {
-  retain :: boolean(),
-  qos :: QOS_0 | QOS_1 | QOS_2,
-  topic :: string(),
-  dup :: boolean(),
-  message_id :: message_id(),
-  payload :: binary()
-}).
-
--endif.
+-type message_id() :: any().
 
 -record(mqtt_frame, {fixed,
                      variable,
@@ -102,9 +89,11 @@
 
 -record(mqtt_frame_other,    {other}).
 
--record(mqtt_msg,            {retain,
-                              qos,
-                              topic,
-                              dup,
-                              message_id,
-                              payload}).
+-record(mqtt_msg,            {retain :: boolean(),
+                              qos :: ?QOS_0 | ?QOS_1 | ?QOS_2,
+                              topic :: string(),
+                              dup :: boolean(),
+                              message_id :: message_id(),
+                              payload :: binary()}).
+
+-type mqtt_msg() :: #mqtt_msg{}.

--- a/src/rabbit_mqtt_retainer.erl
+++ b/src/rabbit_mqtt_retainer.erl
@@ -31,14 +31,10 @@
 -record(retainer_state, {store_mod,
                          store}).
 
--ifdef(use_specs).
-
--spec(retain/3 :: (pid(), string(), mqtt_msg()) ->
+-spec retain(pid(), string(), mqtt_msg()) ->
     {noreply, NewState :: term()} |
     {noreply, NewState :: term(), timeout() | hibernate} |
-    {stop, Reason :: term(), NewState :: term()}).
-
--endif.
+    {stop, Reason :: term(), NewState :: term()}.
 
 %%----------------------------------------------------------------------------
 

--- a/src/rabbit_mqtt_retainer_sup.erl
+++ b/src/rabbit_mqtt_retainer_sup.erl
@@ -22,10 +22,8 @@
 
 -define(ENCODING, utf8).
 
--ifdef(use_specs).
--spec(start_child/1 :: (binary()) -> supervisor2:startchild_ret()).
--spec(start_child/2 :: (term(), binary()) -> supervisor2:startchild_ret()).
--endif.
+-spec start_child(binary()) -> supervisor2:startchild_ret().
+-spec start_child(term(), binary()) -> supervisor2:startchild_ret().
 
 start_link(SupName) ->
   supervisor2:start_link(SupName, ?MODULE, []).


### PR DESCRIPTION
The old format is removed in Erlang 19.0, leading to build errors.

Also, get rid of the `use_specs` macro and thus always define `-spec()` & friends.

While here, unnify the style of `-type` and `-spec`.

References rabbitmq/rabbitmq-server#860.
[#118562897]
[#122335241]