### PR TITLE
Fixed authentication logic.

### DIFF
--- a/test/auth_SUITE.erl
+++ b/test/auth_SUITE.erl
@@ -102,39 +102,39 @@ end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 anonymous_auth_success(Config) ->
-    expect_connect(fun connect_anonymous/1, Config).
+    expect_successful_connection(fun connect_anonymous/1, Config).
 
 anonymous_auth_failure(Config) ->
-    expect_auth_error(fun connect_anonymous/1, Config).
+    expect_authentication_failure(fun connect_anonymous/1, Config).
 
 
 ssl_user_auth_success(Config) ->
-    expect_connect(fun connect_ssl/1, Config).
+    expect_successful_connection(fun connect_ssl/1, Config).
 
 ssl_user_auth_failure(Config) ->
-    expect_auth_error(fun connect_ssl/1, Config).
+    expect_authentication_failure(fun connect_ssl/1, Config).
 
 user_credentials_auth(Config) ->
     NewUser = ?config(new_user, Config),
     NewUserPass = ?config(new_user_pass, Config),
 
-    expect_connect(
+    expect_successful_connection(
         fun(Conf) -> connect_user(NewUser, NewUserPass, Conf) end,
         Config),
 
-    expect_connect(
+    expect_successful_connection(
         fun(Conf) -> connect_user(<<"guest">>, <<"guest">>, Conf) end,
         Config),
 
-    expect_auth_error(
+    expect_authentication_failure(
         fun(Conf) -> connect_user(NewUser, <<"invalid_pass">>, Conf) end,
         Config),
 
-    expect_auth_error(
+    expect_authentication_failure(
         fun(Conf) -> connect_user(undefined, <<"pass">>, Conf) end,
         Config),
 
-    expect_auth_error(
+    expect_authentication_failure(
         fun(Conf) -> connect_user(NewUser, undefined, Conf) end,
         Config).
 
@@ -175,13 +175,13 @@ connect_user(User, Pass, Config) ->
                        {proto_ver, 3},
                        {logger, info}] ++ Creds).
 
-expect_connect(ConnectFun, Config) ->
+expect_successful_connection(ConnectFun, Config) ->
     {ok, C} = ConnectFun(Config),
     receive {mqttc, C, connected} -> emqttc:disconnect(C)
     after ?CONNECT_TIMEOUT -> exit(emqttc_connection_timeout)
     end.
 
-expect_auth_error(ConnectFun, Config) ->
+expect_authentication_failure(ConnectFun, Config) ->
     process_flag(trap_exit, true),
     {ok, C} = ConnectFun(Config),
     Result = receive

--- a/test/auth_SUITE.erl
+++ b/test/auth_SUITE.erl
@@ -1,0 +1,196 @@
+-module(auth_SUITE).
+-compile([export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-define(CONNECT_TIMEOUT, 10000).
+
+all() ->
+    [{group, anonymous_no_ssl_user},
+     {group, anonymous_ssl_user},
+     {group, no_ssl_user},
+     {group, ssl_user}].
+
+groups() ->
+    [{anonymous_ssl_user, [],
+      [anonymous_auth_success,
+       user_credentials_auth,
+       ssl_user_auth_success]},
+     {anonymous_no_ssl_user, [],
+      [anonymous_auth_success,
+       user_credentials_auth]},
+     {ssl_user, [],
+      [anonymous_auth_fail,
+       user_credentials_auth,
+       ssl_user_auth_success]},
+     {no_ssl_user, [],
+      [anonymous_auth_fail,
+       user_credentials_auth,
+       ssl_user_auth_fail]}].
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config.
+
+end_per_suite(Config) ->
+    Config.
+
+init_per_group(Group, Config) ->
+    Suffix = rabbit_ct_helpers:testcase_absname(Config, "", "-"),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Suffix},
+        {rmq_certspwd, "bunnychow"}
+    ]),
+    MqttConfig = mqtt_config(Group),
+    rabbit_ct_helpers:run_setup_steps(Config1,
+        [ fun(Conf) -> merge_app_env(MqttConfig, Conf) end ] ++
+        rabbit_ct_broker_helpers:setup_steps() ++
+        rabbit_ct_client_helpers:setup_steps()).
+
+end_per_group(_, Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+merge_app_env(MqttConfig, Config) ->
+    rabbit_ct_helpers:merge_app_env(Config, MqttConfig).
+
+mqtt_config(anonymous_ssl_user) ->
+    {rabbitmq_mqtt, [{ssl_cert_login,  true},
+                     {allow_anonymous, true}]};
+mqtt_config(anonymous_no_ssl_user) ->
+    {rabbitmq_mqtt, [{ssl_cert_login,  false},
+                     {allow_anonymous, true}]};
+mqtt_config(ssl_user) ->
+    {rabbitmq_mqtt, [{ssl_cert_login,  true},
+                     {allow_anonymous, false}]};
+mqtt_config(no_ssl_user) ->
+    {rabbitmq_mqtt, [{ssl_cert_login,  false},
+                     {allow_anonymous, false}]}.
+
+init_per_testcase(Testcase, Config) when Testcase == ssl_user_auth_success;
+                                         Testcase == ssl_user_auth_fail ->
+    Hostname = re:replace(os:cmd("hostname"), "\\s+", "", [global,{return,list}]),
+    User = "O=client,CN=" ++ Hostname,
+    {ok,_} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["add_user", User, ""]),
+    {ok, _} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["set_permissions",  "-p", "/", User, ".*", ".*", ".*"]),
+    Config1 = rabbit_ct_helpers:set_config(Config, [{temp_ssl_user, User}]),
+    rabbit_ct_helpers:testcase_started(Config1, Testcase);
+init_per_testcase(user_credentials_auth, Config) ->
+    User = <<"new-user">>,
+    Pass = <<"new-user-pass">>,
+    {ok,_} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["add_user", User, Pass]),
+    {ok, _} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["set_permissions",  "-p", "/", User, ".*", ".*", ".*"]),
+    Config1 = rabbit_ct_helpers:set_config(Config, [{new_user, User},
+                                                    {new_user_pass, Pass}]),
+    rabbit_ct_helpers:testcase_started(Config1, user_credentials_auth);
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
+
+end_per_testcase(Testcase, Config) when Testcase == ssl_user_auth_success;
+                                        Testcase == ssl_user_auth_fail ->
+    User = ?config(temp_ssl_user, Config),
+    {ok,_} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["delete_user", User]),
+    rabbit_ct_helpers:testcase_finished(Config, Testcase);
+end_per_testcase(user_credentials_auth, Config) ->
+    User = ?config(new_user, Config),
+    {ok,_} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["delete_user", User]),
+    rabbit_ct_helpers:testcase_finished(Config, user_credentials_auth);
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+anonymous_auth_success(Config) ->
+    expect_connect(fun connect_anonymous/1, Config).
+
+anonymous_auth_fail(Config) ->
+    expect_auth_error(fun connect_anonymous/1, Config).
+
+
+ssl_user_auth_success(Config) ->
+    expect_connect(fun connect_ssl/1, Config).
+
+ssl_user_auth_fail(Config) ->
+    expect_auth_error(fun connect_ssl/1, Config).
+
+user_credentials_auth(Config) ->
+    NewUser = ?config(new_user, Config),
+    NewUserPass = ?config(new_user_pass, Config),
+
+    expect_connect(
+        fun(Conf) -> connect_user(NewUser, NewUserPass, Conf) end,
+        Config),
+
+    expect_connect(
+        fun(Conf) -> connect_user(<<"guest">>, <<"guest">>, Conf) end,
+        Config),
+
+    expect_auth_error(
+        fun(Conf) -> connect_user(NewUser, <<"invalid_pass">>, Conf) end,
+        Config),
+
+    expect_auth_error(
+        fun(Conf) -> connect_user(undefined, <<"pass">>, Conf) end,
+        Config),
+
+    expect_auth_error(
+        fun(Conf) -> connect_user(NewUser, undefined, Conf) end,
+        Config).
+
+
+connect_anonymous(Config) ->
+    P = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
+    emqttc:start_link([{host, "localhost"},
+                       {port, P},
+                       {client_id, <<"simpleClient">>},
+                       {proto_ver, 3},
+                       {logger, info}]).
+
+connect_ssl(Config) ->
+    CertsDir = ?config(rmq_certsdir, Config),
+    SSLConfig = [{cacertfile, filename:join([CertsDir, "testca", "cacert.pem"])},
+                 {certfile, filename:join([CertsDir, "client", "cert.pem"])},
+                 {keyfile, filename:join([CertsDir, "client", "key.pem"])}],
+    P = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt_tls),
+    emqttc:start_link([{host, "localhost"},
+                       {port, P},
+                       {client_id, <<"simpleClient">>},
+                       {proto_ver, 3},
+                       {logger, info},
+                       {ssl, SSLConfig}]).
+
+connect_user(User, Pass, Config) ->
+    Creds = case User of
+        undefined -> [];
+        _         -> [{username, User}]
+    end ++ case Pass of
+        undefined -> [];
+        _         -> [{password, Pass}]
+    end,
+    ct:log("CREDS ~p", [Creds]),
+    P = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
+    emqttc:start_link([{host, "localhost"},
+                       {port, P},
+                       {client_id, <<"simpleClient">>},
+                       {proto_ver, 3},
+                       {logger, info}] ++ Creds).
+
+expect_connect(ConnectFun, Config) ->
+    {ok, C} = ConnectFun(Config),
+    receive {mqttc, C, connected} -> emqttc:disconnect(C)
+    after ?CONNECT_TIMEOUT -> exit(emqttc_connection_timeout)
+    end.
+
+expect_auth_error(ConnectFun, Config) ->
+    process_flag(trap_exit, true),
+    {ok, C} = ConnectFun(Config),
+    Result = receive
+        {mqttc, C, connected} -> {error, unexpected_anonymous_connection};
+        {'EXIT', C, {shutdown,{connack_error,'CONNACK_CREDENTIALS'}}} -> ok
+    after
+        ?CONNECT_TIMEOUT -> {error, emqttc_connection_timeout}
+    end,
+    process_flag(trap_exit, false),
+    case Result of
+        ok -> ok;
+        {error, Err} -> exit(Err)
+    end.

--- a/test/auth_SUITE.erl
+++ b/test/auth_SUITE.erl
@@ -22,13 +22,13 @@ groups() ->
        %% SSL auth will succeed, because we cannot ignore anonymous
        ]},
      {ssl_user, [],
-      [anonymous_auth_fail,
+      [anonymous_auth_failure,
        user_credentials_auth,
        ssl_user_auth_success]},
      {no_ssl_user, [],
-      [anonymous_auth_fail,
+      [anonymous_auth_failure,
        user_credentials_auth,
-       ssl_user_auth_fail]}].
+       ssl_user_auth_failure]}].
 
 init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
@@ -71,7 +71,7 @@ mqtt_config(no_ssl_user) ->
                      {allow_anonymous, false}]}.
 
 init_per_testcase(Testcase, Config) when Testcase == ssl_user_auth_success;
-                                         Testcase == ssl_user_auth_fail ->
+                                         Testcase == ssl_user_auth_failure ->
     Hostname = re:replace(os:cmd("hostname"), "\\s+", "", [global,{return,list}]),
     User = "O=client,CN=" ++ Hostname,
     {ok,_} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["add_user", User, ""]),
@@ -90,7 +90,7 @@ init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) when Testcase == ssl_user_auth_success;
-                                        Testcase == ssl_user_auth_fail ->
+                                        Testcase == ssl_user_auth_failure ->
     User = ?config(temp_ssl_user, Config),
     {ok,_} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["delete_user", User]),
     rabbit_ct_helpers:testcase_finished(Config, Testcase);
@@ -104,14 +104,14 @@ end_per_testcase(Testcase, Config) ->
 anonymous_auth_success(Config) ->
     expect_connect(fun connect_anonymous/1, Config).
 
-anonymous_auth_fail(Config) ->
+anonymous_auth_failure(Config) ->
     expect_auth_error(fun connect_anonymous/1, Config).
 
 
 ssl_user_auth_success(Config) ->
     expect_connect(fun connect_ssl/1, Config).
 
-ssl_user_auth_fail(Config) ->
+ssl_user_auth_failure(Config) ->
     expect_auth_error(fun connect_ssl/1, Config).
 
 user_credentials_auth(Config) ->

--- a/test/auth_SUITE.erl
+++ b/test/auth_SUITE.erl
@@ -18,7 +18,9 @@ groups() ->
        ssl_user_auth_success]},
      {anonymous_no_ssl_user, [],
       [anonymous_auth_success,
-       user_credentials_auth]},
+       user_credentials_auth
+       %% SSL auth will succeed, because we cannot ignore anonymous
+       ]},
      {ssl_user, [],
       [anonymous_auth_fail,
        user_credentials_auth,
@@ -166,7 +168,6 @@ connect_user(User, Pass, Config) ->
         undefined -> [];
         _         -> [{password, Pass}]
     end,
-    ct:log("CREDS ~p", [Creds]),
     P = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
     emqttc:start_link([{host, "localhost"},
                        {port, P},

--- a/test/java_SUITE.erl
+++ b/test/java_SUITE.erl
@@ -24,7 +24,7 @@
 -define(BASE_CONF_MQTT,
         {rabbitmq_mqtt, [
            {ssl_cert_login,   true},
-           {allow_anonymous,  true},
+           {allow_anonymous,  false},
            {tcp_listeners,    []},
            {ssl_listeners,    []}
            ]}).

--- a/test/java_SUITE_data/src/com/rabbitmq/mqtt/test/MqttTest.java
+++ b/test/java_SUITE_data/src/com/rabbitmq/mqtt/test/MqttTest.java
@@ -277,10 +277,12 @@ public class MqttTest extends TestCase implements MqttCallback {
     }
 
     public void testEmptyPassword() throws MqttException {
-        conOpt.setUserName("guest");
-        conOpt.setPassword(null);
+        MqttClient c = new MqttClient(brokerUrl, clientId, null);
+        MqttConnectOptions opts = new MyConnOpts();
+        opts.setUserName("guest");
+        opts.setPassword(null);
         try {
-            client.connect(conOpt);
+            c.connect(opts);
             fail("Authentication failure expected");
         } catch (MqttException ex) {
             Assert.assertEquals(MqttException.REASON_CODE_FAILED_AUTHENTICATION, ex.getReasonCode());
@@ -447,7 +449,7 @@ public class MqttTest extends TestCase implements MqttCallback {
         client.disconnect();
     }
 
-    public void  testSessionRedelivery() throws MqttException, InterruptedException {
+    public void testSessionRedelivery() throws MqttException, InterruptedException {
         conOpt.setCleanSession(false);
         client.connect(conOpt);
         client.subscribe(topic, 1);

--- a/test/java_SUITE_data/src/com/rabbitmq/mqtt/test/MqttTest.java
+++ b/test/java_SUITE_data/src/com/rabbitmq/mqtt/test/MqttTest.java
@@ -155,6 +155,8 @@ public class MqttTest extends TestCase implements MqttCallback {
         // conOpts.setPassword("guest".toCharArray());
         conOpts.setCleanSession(true);
         conOpts.setKeepAliveInterval(60);
+        conOpts.setUserName("guest");
+        conOpts.setPassword("guest".toCharArray());
     }
 
     public void testConnectFirst() throws MqttException, IOException, InterruptedException {
@@ -227,6 +229,8 @@ public class MqttTest extends TestCase implements MqttCallback {
             throws MqttException, IOException, TimeoutException, InterruptedException {
         MqttClient c = new MqttClient(brokerUrl, cid, null);
         MqttConnectOptions opts = new MyConnOpts();
+        opts.setUserName("guest");
+        opts.setPassword("guest".toCharArray());
         opts.setCleanSession(cleanSession);
         c.connect(opts);
 
@@ -264,6 +268,17 @@ public class MqttTest extends TestCase implements MqttCallback {
     public void testInvalidPassword() throws MqttException {
         conOpt.setUserName("invalid-user");
         conOpt.setPassword("invalid-password".toCharArray());
+        try {
+            client.connect(conOpt);
+            fail("Authentication failure expected");
+        } catch (MqttException ex) {
+            Assert.assertEquals(MqttException.REASON_CODE_FAILED_AUTHENTICATION, ex.getReasonCode());
+        }
+    }
+
+    public void testEmptyPassword() throws MqttException {
+        conOpt.setUserName("guest");
+        conOpt.setPassword(null);
         try {
             client.connect(conOpt);
             fail("Authentication failure expected");


### PR DESCRIPTION
Fixes #96 

The problem was that username and password fields had been checked separately and anonymous and SSL auth modes could interfere with this credentials. So a username without a password was treated like a SSL username and an anonymous password can be added to a non-anonymous username.

The new logic corresponds with the plugin documentation. If any credential (username or password) is provided, default credentials and SSL auth are ignored. If only one of the credentials is provided an error is reported.