### PR TITLE
Fix `clean` make target for source dist tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ include erlang.mk
 
 
 clean::
-	cd test/java_SUITE_data && make clean
+	if test -d test/java_SUITE_data; then cd test/java_SUITE_data && make clean; fi


### PR DESCRIPTION
Source dist tarballs made by `rabbitmq-server-release` doesn't include
testsuites, so `clean` target breaks under such conditions.

Complements https://github.com/rabbitmq/rabbitmq-server-release/pull/4