### PR TITLE
Support Erlang string vhosts in retainer supervisor

### DIFF
--- a/src/rabbit_mqtt_retainer_sup.erl
+++ b/src/rabbit_mqtt_retainer_sup.erl
@@ -39,12 +39,12 @@ start_child(VHost) when is_binary(VHost) ->
 
 start_child(RetainStoreMod, VHost) ->
   supervisor2:start_child(?MODULE,
-    {binary_to_atom(VHost, ?ENCODING),
+    {rabbit_data_coercion:to_atom(VHost),
       {rabbit_mqtt_retainer, start_link, [RetainStoreMod, VHost]},
       permanent, 60, worker, [rabbit_mqtt_retainer]}).
 
 delete_child(VHost) ->
-  Id = binary_to_atom(VHost, ?ENCODING),
+  Id = rabbit_data_coercion:to_atom(VHost),
   ok = supervisor2:terminate_child(?MODULE, Id),
   ok = supervisor2:delete_child(?MODULE, Id).
 
@@ -55,6 +55,6 @@ init([]) ->
   {ok, {{one_for_one, 5, 5}, child_specs(Mod, rabbit_vhost:list())}}.
 
 child_specs(Mod, VHosts) ->
-  [{binary_to_atom(V, ?ENCODING),
+  [{rabbit_data_coercion:to_atom(V),
       {rabbit_mqtt_retainer, start_link, [Mod, V]},
       permanent, infinity, worker, [rabbit_mqtt_retainer]} || V <- VHosts].

--- a/test/retainer_SUITE.erl
+++ b/test/retainer_SUITE.erl
@@ -1,0 +1,91 @@
+-module(retainer_SUITE).
+-compile([export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+
+all() ->
+    [
+        {group, non_parallel_tests}
+    ].
+
+groups() ->
+    [
+        {non_parallel_tests, [], [
+            coerce_configuration_data
+        ]}
+    ].
+
+suite() ->
+    [{timetrap, {seconds, 60}}].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, ?MODULE},
+        {rmq_extra_tcp_ports, [tcp_port_mqtt_extra,
+            tcp_port_mqtt_tls_extra]}
+    ]),
+    % see https://github.com/rabbitmq/rabbitmq-mqtt/issues/86
+    RabbitConfig = {rabbit, [
+        {default_user, "guest"},
+        {default_pass, "guest"},
+        {default_vhost, "/"},
+        {default_permissions, [".*", ".*", ".*"]}
+    ]},
+    rabbit_ct_helpers:run_setup_steps(Config1,
+        [ fun(Conf) -> merge_app_env(RabbitConfig, Conf) end ] ++
+            rabbit_ct_broker_helpers:setup_steps() ++
+            rabbit_ct_client_helpers:setup_steps()).
+
+merge_app_env(MqttConfig, Config) ->
+    rabbit_ct_helpers:merge_app_env(Config, MqttConfig).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config,
+        rabbit_ct_client_helpers:teardown_steps() ++
+        rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_group(_, Config) ->
+    Config.
+
+end_per_group(_, Config) ->
+    Config.
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+
+%% -------------------------------------------------------------------
+%% Testsuite cases
+%% -------------------------------------------------------------------
+
+coerce_configuration_data(Config) ->
+    P = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
+    {ok, C} = emqttc:start_link([{host, "localhost"},
+        {port, P},
+        {client_id, <<"simpleClientRetainer">>},
+        {proto_ver, 3},
+        {logger, info},
+        {puback_timeout, 1}]),
+
+    emqttc:subscribe(C, <<"TopicA">>, qos0),
+    emqttc:publish(C, <<"TopicA">>, <<"Payload">>),
+    expect_publishes(<<"TopicA">>, [<<"Payload">>]),
+
+    emqttc:disconnect(C),
+    ok.
+
+expect_publishes(_Topic, []) -> ok;
+expect_publishes(Topic, [Payload|Rest]) ->
+    receive
+        {publish, Topic, Payload} -> expect_publishes(Topic, Rest)
+    after 500 ->
+        throw({publish_not_delivered, Payload})
+    end.


### PR DESCRIPTION
Fixes #86 

https://github.com/rabbitmq/rabbitmq-server/pull/1051 and https://github.com/rabbitmq/rabbitmq-common/pull/153 need to be merged first.