### PR TITLE
Use check_topic_access on publishing

### DIFF
--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -177,7 +177,7 @@ process_request(?PUBLISH,
                                                   message_id = MessageId },
                   payload = Payload },
                   PState = #proc_state{retainer_pid = RPid}) ->
-    check_publish_or_die(Topic, fun() ->
+    check_publish(Topic, fun() ->
         Msg = #mqtt_msg{retain     = Retain,
                         qos        = Qos,
                         topic      = Topic,
@@ -202,7 +202,7 @@ process_request(?SUBSCRIBE,
                             exchange = Exchange,
                             retainer_pid = RPid,
                             send_fun = SendFun } = PState0) ->
-    check_subscribe_or_die(Topics, fun() ->
+    check_subscribe(Topics, fun() ->
         {QosResponse, PState1} =
             lists:foldl(fun (#mqtt_topic{name = TopicName,
                                          qos  = Qos}, {QosList, PState}) ->
@@ -785,22 +785,22 @@ close_connection(PState = #proc_state{ connection = Connection,
     PState #proc_state{ channels   = {undefined, undefined},
                         connection = undefined }.
 
-% NB: check_*_or_die: MQTT spec says we should ack normally, ie pretend there
+% NB: check_*: MQTT spec says we should ack normally, ie pretend there
 % was no auth error, but here we are closing the connection with an error. This
 % is what happens anyway if there is an authorization failure at the AMQP level.
 
-check_publish_or_die(TopicName, Fn, PState) ->
+check_publish(TopicName, Fn, PState) ->
   case check_topic_access(TopicName, write, PState) of
     ok -> Fn();
     _ -> {err, unauthorized, PState}
   end.
 
-check_subscribe_or_die([], Fn, _) ->
+check_subscribe([], Fn, _) ->
   Fn();
 
-check_subscribe_or_die([#mqtt_topic{name = TopicName} | Topics], Fn, PState) ->
+check_subscribe([#mqtt_topic{name = TopicName} | Topics], Fn, PState) ->
   case check_topic_access(TopicName, read, PState) of
-    ok -> check_subscribe_or_die(Topics, Fn, PState);
+    ok -> check_subscribe(Topics, Fn, PState);
     _ -> {err, unauthorized, PState}
   end.
 
@@ -813,7 +813,14 @@ check_topic_access(TopicName, write = Access,
                        kind = topic,
                        name = Exchange},
   Context = #{routing_key => rabbit_mqtt_util:mqtt2amqp(TopicName)},
-  rabbit_access_control:check_topic_access(User, Resource, Access, Context);
+
+    try rabbit_access_control:check_topic_access(User, Resource, Access, Context) of
+        R -> R
+    catch
+        _:Error ->
+            rabbit_log:error("~p~n", [Error]),
+            {error, access_refused}
+    end;
 check_topic_access(TopicName, read = Access,
                    #proc_state{
                       auth_state = #auth_state{user = User,
@@ -821,8 +828,13 @@ check_topic_access(TopicName, read = Access,
   Resource = #resource{virtual_host = VHost,
                        kind = topic,
                        name = TopicName},
-  rabbit_access_control:check_resource_access(User, Resource, Access).
-
+  try rabbit_access_control:check_resource_access(User, Resource, Access) of
+      R -> R
+  catch
+      _:Error ->
+          rabbit_log:error("~p~n", [Error]),
+          {error, access_refused}
+  end.
 
 info(consumer_tags, #proc_state{consumer_tags = Val}) -> Val;
 info(unacked_pubs, #proc_state{unacked_pubs = Val}) -> Val;

--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -804,7 +804,17 @@ check_subscribe_or_die([#mqtt_topic{name = TopicName} | Topics], Fn, PState) ->
     _ -> {err, unauthorized, PState}
   end.
 
-check_topic_access(TopicName, Access,
+check_topic_access(TopicName, write = Access,
+                   #proc_state{
+                        auth_state = #auth_state{user = User,
+                                                 vhost = VHost},
+                        exchange = Exchange}) ->
+  Resource = #resource{virtual_host = VHost,
+                       kind = topic,
+                       name = Exchange},
+  Context = #{routing_key => rabbit_mqtt_util:mqtt2amqp(TopicName)},
+  rabbit_access_control:check_topic_access(User, Resource, Access, Context);
+check_topic_access(TopicName, read = Access,
                    #proc_state{
                       auth_state = #auth_state{user = User,
                                                vhost = VHost}}) ->

--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -818,7 +818,7 @@ check_topic_access(TopicName, write = Access,
         R -> R
     catch
         _:{amqp_error, access_refused, Msg, _} ->
-            rabbit_log:error("operation resulted in a topic error access_refused: ~p~n", [Msg]),
+            rabbit_log:error("operation resulted in an error (access_refused): ~p~n", [Msg]),
             {error, access_refused};
         _:Error ->
             rabbit_log:error("~p~n", [Error]),
@@ -835,7 +835,7 @@ check_topic_access(TopicName, read = Access,
       R -> R
   catch
       _:{amqp_error, access_refused, Msg, _} ->
-          rabbit_log:error("operation resulted in a topic error access_refused: ~p~n", [Msg]),
+          rabbit_log:error("operation resulted in an error (access_refused): ~p~n", [Msg]),
           {error, access_refused};
       _:Error ->
           rabbit_log:error("~p~n", [Error]),

--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -817,6 +817,9 @@ check_topic_access(TopicName, write = Access,
     try rabbit_access_control:check_topic_access(User, Resource, Access, Context) of
         R -> R
     catch
+        _:{amqp_error, access_refused, Msg, _} ->
+            rabbit_log:error("operation resulted in a topic error access_refused: ~p~n", [Msg]),
+            {error, access_refused};
         _:Error ->
             rabbit_log:error("~p~n", [Error]),
             {error, access_refused}
@@ -831,6 +834,9 @@ check_topic_access(TopicName, read = Access,
   try rabbit_access_control:check_resource_access(User, Resource, Access) of
       R -> R
   catch
+      _:{amqp_error, access_refused, Msg, _} ->
+          rabbit_log:error("operation resulted in a topic error access_refused: ~p~n", [Msg]),
+          {error, access_refused};
       _:Error ->
           rabbit_log:error("~p~n", [Error]),
           {error, access_refused}

--- a/src/rabbit_mqtt_reader.erl
+++ b/src/rabbit_mqtt_reader.erl
@@ -280,7 +280,9 @@ process_received_bytes(Bytes,
                         [Error, ConnStr]),
                     {stop, {shutdown, Error}, State};
                 {stop, ProcState1} ->
-                    {stop, normal, pstate(State, ProcState1)}
+                    {stop, normal, pstate(State, ProcState1)};
+                {err, unauthorized = Reason, ProcState1} ->
+                    {stop, {shutdown, Reason}, pstate(State, ProcState1)}
             end;
         {error, Error} ->
             log(error, "MQTT detected framing error '~p' for connection ~p~n",

--- a/test/java_SUITE.erl
+++ b/test/java_SUITE.erl
@@ -81,6 +81,7 @@ init_per_testcase(Testcase, Config) ->
     User = "O=client,CN=" ++ Hostname,
     {ok,_} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["add_user", User, ""]),
     {ok, _} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["set_permissions",  "-p", "/", User, ".*", ".*", ".*"]),
+    {ok, _} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["set_topic_permissions",  "-p", "/", "guest", "amq.topic", "test-topic|test-retained-topic|.*mid.*|.*topic.*"]),
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->

--- a/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/MqttTest.java
+++ b/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/MqttTest.java
@@ -665,6 +665,22 @@ public class MqttTest implements MqttCallback {
         }
     }
 
+    @Test public void topicAuthorisation() throws Exception {
+        client.connect(conOpt);
+        client.setCallback(this);
+        client.subscribe("some/topic");
+        publish(client, "some/topic", 1, "content".getBytes());
+        waitAtMost(timeout).untilCall(to(this).receivedMessagesSize(),equalTo(1));
+        assertTrue(client.isConnected());
+        try {
+            publish(client, "forbidden", 1, "content".getBytes());
+            fail("Publishing on a forbidden topic, an exception should have been thrown");
+            client.disconnect();
+        } catch(Exception e) {
+            // OK
+        }
+    }
+
     @Test public void interopM2A() throws MqttException, IOException, InterruptedException, TimeoutException {
         setUpAmqp();
         String queue = ch.queueDeclare().getQueue();

--- a/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/rabbit-test.sh
+++ b/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/rabbit-test.sh
@@ -5,3 +5,4 @@ USER="O=client,CN=$(hostname)"
 # Test direct connections
 $CTL add_user "$USER" ''
 $CTL set_permissions -p / "$USER" ".*" ".*" ".*"
+$CTL set_topic_permissions -p / "$USER" "amq.topic" "test-topic|test-retained-topic|.*mid.*|.*topic.*"


### PR DESCRIPTION
check_resource_access used to be called with
the MQTT topic as resource name and kind = topic.
It makes more sense now to call check_topic_access
with the exchange as resource name, kind = topic,
and routing key in the context.

References rabbitmq/rabbitmq-server#505, closes #95 .