### PR TITLE
Don't use UTF-8 when calculating retainer_sup child names

### DIFF
--- a/src/rabbit_mqtt_retainer_sup.erl
+++ b/src/rabbit_mqtt_retainer_sup.erl
@@ -39,12 +39,13 @@ start_child(VHost) when is_binary(VHost) ->
 
 start_child(RetainStoreMod, VHost) ->
   supervisor2:start_child(?MODULE,
-    {rabbit_data_coercion:to_atom(VHost),
+
+    {vhost_to_atom(VHost),
       {rabbit_mqtt_retainer, start_link, [RetainStoreMod, VHost]},
       permanent, 60, worker, [rabbit_mqtt_retainer]}).
 
 delete_child(VHost) ->
-  Id = rabbit_data_coercion:to_atom(VHost),
+  Id = vhost_to_atom(VHost),
   ok = supervisor2:terminate_child(?MODULE, Id),
   ok = supervisor2:delete_child(?MODULE, Id).
 
@@ -55,6 +56,14 @@ init([]) ->
   {ok, {{one_for_one, 5, 5}, child_specs(Mod, rabbit_vhost:list())}}.
 
 child_specs(Mod, VHosts) ->
-  [{rabbit_data_coercion:to_atom(V),
+  %% see start_child/2
+  [{vhost_to_atom(V),
       {rabbit_mqtt_retainer, start_link, [Mod, V]},
       permanent, infinity, worker, [rabbit_mqtt_retainer]} || V <- VHosts].
+
+vhost_to_atom(VHost) ->
+    %% we'd like to avoid any conversion here because
+    %% this atom isn't meant to be human-readable, only
+    %% unique. This makes sure we don't get noisy process restarts
+    %% with really unusual vhost names used by various HTTP API test suites
+    rabbit_data_coercion:to_atom(VHost, latin1).


### PR DESCRIPTION
Such conversion isn't safe but also isn't necessary: those
names aren't supposed to be human-readable.

Fixes #123.