### PR TITLE
Check topic access when sending last will

### DIFF
--- a/test/command_SUITE.erl
+++ b/test/command_SUITE.erl
@@ -148,8 +148,7 @@ run(Config) ->
 
 
 start_amqp_connection(Type, Node, Port) ->
-    Params = amqp_params(Type, Node, Port),
-    {ok, Connection} = amqp_connection:start(Params).
+    amqp_connection:start(amqp_params(Type, Node, Port)).
 
 amqp_params(network, _, Port) ->
     #amqp_params_network{port = Port};

--- a/test/java_SUITE.erl
+++ b/test/java_SUITE.erl
@@ -84,7 +84,7 @@ init_per_testcase(Testcase, Config) ->
     {ok, _} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0,
         ["set_topic_permissions",  "-p", "/", "guest", "amq.topic",
             "test-topic|test-retained-topic|.*mid.*|.*topic.*",
-            "test-topic|test-retained-topic|.*mid.*|.*topic.*"]),
+            "test-topic|test-retained-topic|.*mid.*|.*topic.*|last-will"]),
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->

--- a/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/rabbit-test.sh
+++ b/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/rabbit-test.sh
@@ -5,4 +5,4 @@ USER="O=client,CN=$(hostname)"
 # Test direct connections
 $CTL add_user "$USER" ''
 $CTL set_permissions -p / "$USER" ".*" ".*" ".*"
-$CTL set_topic_permissions -p / "$USER" "amq.topic" "test-topic|test-retained-topic|.*mid.*|.*topic.*"
+$CTL set_topic_permissions -p / "$USER" "amq.topic" "test-topic|test-retained-topic|.*mid.*|.*topic.*" "test-topic|test-retained-topic|.*mid.*|.*topic.*|last-will"


### PR DESCRIPTION
The check is actually already done at the AMQP level, but this commit
adds an "upstream" check, a more specific warning message, and a test.

Fixes #114