### PR TITLE
Log MQTT processor log messages with connection sink.

### DIFF
--- a/src/rabbit_mqtt_collector.erl
+++ b/src/rabbit_mqtt_collector.erl
@@ -85,8 +85,9 @@ handle_info({'DOWN', MRef, process, DownPid, _Reason},
             State = #state{client_ids = Ids}) ->
     Ids1 = dict:filter(fun (ClientId, {Pid, M})
                            when Pid =:= DownPid, MRef =:= M ->
-                               rabbit_log:warning("MQTT disconnect from ~p~n",
-                                                  [ClientId]),
+                               rabbit_log:log(connection, warning,
+                                              "MQTT disconnect from ~p~n",
+                                              [ClientId]),
                                false;
                            (_, _) ->
                                true


### PR DESCRIPTION
It is still up to discussion if the log sink should be `connection` or `channel`.

Fixes #142