### PR TITLE
Replace broken link with correct Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is an MQTT plugin for RabbitMQ.
 
 The plugin is included in the RabbitMQ distribution.  To enable
-it, use <href="http://www.rabbitmq.com/man/rabbitmq-plugins.1.man.html">rabbitmq-plugins</a>:
+it, use [rabbitmq-plugins](http://www.rabbitmq.com/man/rabbitmq-plugins.1.man.html):
 
     rabbitmq-plugins enable rabbitmq_mqtt
 


### PR DESCRIPTION
## Proposed Changes

The HTML link to rabbitmq-plugins in the README was broken (missing `a`), so I fixed it by replacing it with the correct Markdown markup, which the rest of the document uses.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

None.
