### PR TITLE
Support global parameter values that are maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.beam
 .erlang.mk/
 cover/
+debug/*
 deps/
 doc/
 ebin/

--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -594,7 +594,8 @@ get_vhost_username(UserBin) ->
 get_vhost_from_user_mapping(_User, not_found) ->
     undefined;
 get_vhost_from_user_mapping(User, Mapping) ->
-    case rabbit_misc:pget(User, Mapping) of
+    M = rabbit_data_coercion:to_proplist(Mapping),
+    case rabbit_misc:pget(User, M) of
         undefined ->
             undefined;
         VHost ->
@@ -604,7 +605,8 @@ get_vhost_from_user_mapping(User, Mapping) ->
 get_vhost_from_port_mapping(_Port, not_found) ->
     undefined;
 get_vhost_from_port_mapping(Port, Mapping) ->
-    Res = case rabbit_misc:pget(rabbit_data_coercion:to_binary(Port), Mapping) of
+    M = rabbit_data_coercion:to_proplist(Mapping),
+    Res = case rabbit_misc:pget(rabbit_data_coercion:to_binary(Port), M) of
         undefined ->
             undefined;
         VHost ->


### PR DESCRIPTION
Support global parameter values that are maps (as well as proplists).

Part of #156, rabbitmq/rabbitmq-management#528.