### PR TITLE
Use 10 TLS connection acceptors by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ define PROJECT_ENV
 	    {retained_message_store_dets_sync_interval, 2000},
 	    {prefetch, 10},
 	    {ssl_listeners, []},
-	    {num_ssl_acceptors, 1},
 	    {tcp_listeners, [1883]},
 	    {num_tcp_acceptors, 10},
+	    {num_ssl_acceptors, 10},
 	    {tcp_listen_options, [{backlog,   128},
 	                          {nodelay,   true}]},
 	    {proxy_protocol, false}

--- a/priv/schema/rabbitmq_mqtt.schema
+++ b/priv/schema/rabbitmq_mqtt.schema
@@ -147,7 +147,7 @@ end}.
 %% and SSL listeners.
 %%
 %% {num_tcp_acceptors, 10},
-%% {num_ssl_acceptors, 1},
+%% {num_ssl_acceptors, 10},
 
 {mapping, "mqtt.num_acceptors.ssl", "rabbitmq_mqtt.num_ssl_acceptors", [
     {datatype, integer}

--- a/src/rabbit_mqtt_sup.erl
+++ b/src/rabbit_mqtt_sup.erl
@@ -31,7 +31,7 @@ init([{Listeners, SslListeners0}]) ->
         = case SslListeners0 of
               [] -> {none, 0, []};
               _  -> {rabbit_networking:ensure_ssl(),
-                     application:get_env(rabbitmq_mqtt, num_ssl_acceptors, 1),
+                     application:get_env(rabbitmq_mqtt, num_ssl_acceptors, 10),
                      case rabbit_networking:poodle_check('MQTT') of
                          ok     -> SslListeners0;
                          danger -> []
@@ -58,13 +58,13 @@ tcp_listener_spec([Address, SocketOpts, NumAcceptors]) ->
     rabbit_networking:tcp_listener_spec(
       rabbit_mqtt_listener_sup, Address, SocketOpts,
       transport(mqtt), rabbit_mqtt_connection_sup, [],
-      mqtt, NumAcceptors, "MQTT TCP Listener").
+      mqtt, NumAcceptors, "MQTT TCP listener").
 
 ssl_listener_spec([Address, SocketOpts, SslOpts, NumAcceptors]) ->
     rabbit_networking:tcp_listener_spec(
       rabbit_mqtt_listener_sup, Address, SocketOpts ++ SslOpts,
       transport('mqtt/ssl'), rabbit_mqtt_connection_sup, [],
-      'mqtt/ssl', NumAcceptors, "MQTT SSL Listener").
+      'mqtt/ssl', NumAcceptors, "MQTT TLS listener").
 
 transport(Protocol) ->
     ProxyProtocol = application:get_env(rabbitmq_mqtt, proxy_protocol, false),


### PR DESCRIPTION
## Proposed Changes

Bumps number of TLS connection acceptors to 10 by default. See rabbitmq/rabbitmq-server#1729
for context.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue rabbitmq/rabbitmq-server#1729)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of rabbitmq/rabbitmq-server#1729.

[#161136615]