### PR TITLE
Fix translation issue with retained messages.

### DIFF
--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -334,7 +334,7 @@ maybe_send_retained_message(RPid, #mqtt_topic{name = S, qos = SubscribeQos}, Msg
                     retain = Msg#mqtt_msg.retain
                  }, variable = #mqtt_frame_publish{
                     message_id = Id,
-                    topic_name = S
+                    topic_name = rabbit_mqtt_util:amqp2mqtt(S)
                  },
                  payload = Msg#mqtt_msg.payload}, PState),
                  case Qos of

--- a/src/rabbit_mqtt_retainer.erl
+++ b/src/rabbit_mqtt_retainer.erl
@@ -42,16 +42,16 @@ start_link(RetainStoreMod, VHost) ->
     gen_server2:start_link(?MODULE, [RetainStoreMod, VHost], []).
 
 retain(Pid, Topic, Msg = #mqtt_msg{retain = true}) ->
-    gen_server2:cast(Pid, {retain, Topic, Msg});
+    gen_server2:cast(Pid, {retain, rabbit_mqtt_util:amqp2mqtt(Topic), Msg});
 
 retain(_Pid, _Topic, Msg = #mqtt_msg{retain = false}) ->
     throw({error, {retain_is_false, Msg}}).
 
 fetch(Pid, Topic) ->
-    gen_server2:call(Pid, {fetch, Topic}, ?TIMEOUT).
+    gen_server2:call(Pid, {fetch, rabbit_mqtt_util:amqp2mqtt(Topic)}, ?TIMEOUT).
 
 clear(Pid, Topic) ->
-    gen_server2:cast(Pid, {clear, Topic}).
+    gen_server2:cast(Pid, {clear, rabbit_mqtt_util:amqp2mqtt(Topic)}).
 
 %%----------------------------------------------------------------------------
 

--- a/test/retainer_SUITE.erl
+++ b/test/retainer_SUITE.erl
@@ -11,12 +11,15 @@ all() ->
 groups() ->
     [
         {non_parallel_tests, [], [
-            coerce_configuration_data
+            coerce_configuration_data,
+	        should_translate_amqp2mqtt_on_publish,
+            should_translate_amqp2mqtt_on_retention,
+            should_translate_amqp2mqtt_on_retention_search
         ]}
     ].
 
 suite() ->
-    [{timetrap, {seconds, 60}}].
+    [{timetrap, {seconds, 600}}].
 
 %% -------------------------------------------------------------------
 %% Testsuite setup/teardown.
@@ -89,3 +92,60 @@ expect_publishes(Topic, [Payload|Rest]) ->
     after 500 ->
         throw({publish_not_delivered, Payload})
     end.
+
+%% -------------------------------------------------------------------
+%% When a client is subscribed to TopicA/Device.Field and another
+%% client publishes to TopicA/Device.Field the client should be
+%% sent messages for the translated topic (TopicA/Device/Field)
+%% -------------------------------------------------------------------
+should_translate_amqp2mqtt_on_publish(Config) ->
+    P = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
+    {ok, C} = emqttc:start_link([{host, "localhost"},
+				 {port, P},
+				 {client_id, <<"simpleClientRetainer">>},
+				{proto_ver,3},
+				{logger, info},
+				{puback_timeout, 1}]),
+	emqttc:subscribe(C, <<"TopicA/Device.Field">>, qos1),
+	emqttc:publish(C,<<"TopicA/Device.Field">>, <<"Payload">>, [{retain,true}]),
+	expect_publishes(<<"TopicA/Device/Field">>, [<<"Payload">>]),
+	emqttc:disconnect(C),
+	ok.
+
+%% -------------------------------------------------------------------
+%% If a client is publishes a retained message to TopicA/Device.Field and another
+%% client subscribes to TopicA/Device.Field the client should be
+%% sent the retained message for the translated topic (TopicA/Device/Field)
+%% -------------------------------------------------------------------
+should_translate_amqp2mqtt_on_retention(Config) ->
+    P = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
+    {ok, C} = emqttc:start_link([{host, "localhost"},
+				 {port, P},
+				 {client_id, <<"simpleClientRetainer">>},
+				{proto_ver,3},
+				{logger, info},
+				{puback_timeout, 1}]),
+	emqttc:publish(C,<<"TopicA/Device.Field">>, <<"Payload">>, [{retain,true}]),
+	emqttc:subscribe(C, <<"TopicA/Device.Field">>, qos1),
+	expect_publishes(<<"TopicA/Device/Field">>, [<<"Payload">>]),
+	emqttc:disconnect(C),
+	ok.
+
+%% -------------------------------------------------------------------
+%% If a client is publishes a retained message to TopicA/Device.Field and another
+%% client subscribes to TopicA/Device.Field the client should be
+%% sent retained message for the translated topic (TopicA/Device/Field)
+%% -------------------------------------------------------------------
+should_translate_amqp2mqtt_on_retention_search(Config) ->
+    P = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
+    {ok, C} = emqttc:start_link([{host, "localhost"},
+				 {port, P},
+				 {client_id, <<"simpleClientRetainer">>},
+				{proto_ver,3},
+				{logger, info},
+				{puback_timeout, 1}]),
+	emqttc:publish(C,<<"TopicA/Device.Field">>, <<"Payload">>, [{retain,true}]),
+	emqttc:subscribe(C, <<"TopicA/Device/Field">>, qos1),
+	expect_publishes(<<"TopicA/Device/Field">>, [<<"Payload">>]),
+	emqttc:disconnect(C),
+	ok.


### PR DESCRIPTION
## Proposed Changes
The message retainer for MQTT messages was using the raw topic instead of the translated topic (amqp2mqtt). This caused unexpected behavior when subscribing to topics that contained dots.  

Non-retained messages being delivered to clients currently have the topic translated to MQTT (slash). This PR improves upon that by: making sure that the topic_name returned for a retained message is in MQTT(slash) format and retains the topic in MQTT (slash) format. 

I also increased the timeout for the tests, my development machine (VM on NAS) was not able to complete the test in < 60 seconds.

## Types of Changes
Not sure if this would be considered a breaking change or a bug fix.

- [x] Bug fix (non-breaking change which fixes issue #175)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments