### PR TITLE
Cluster-wide MQTT client id tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ define PROJECT_APP_EXTRA_KEYS
 	{broker_version_requirements, []}
 endef
 
-DEPS = ranch rabbit_common rabbit amqp_client
+DEPS = ranch rabbit_common rabbit amqp_client ra
 TEST_DEPS = emqttc ct_helper rabbitmq_ct_helpers rabbitmq_ct_client_helpers
 
 dep_ct_helper = git https://github.com/extend/ct_helper.git master

--- a/include/mqtt_machine.hrl
+++ b/include/mqtt_machine.hrl
@@ -11,5 +11,7 @@
 %% The Original Code is RabbitMQ.
 %%
 %% The Initial Developer of the Original Code is GoPivotal, Inc.
-%% Copyright (c) 2007-2019 GoPivotal, Inc.  All rights reserved.
+%% Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 %%
+
+-record(machine_state, {client_ids = #{}}).

--- a/include/rabbit_mqtt.hrl
+++ b/include/rabbit_mqtt.hrl
@@ -11,7 +11,7 @@
 %% The Original Code is RabbitMQ.
 %%
 %% The Initial Developer of the Original Code is GoPivotal, Inc.
-%% Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+%% Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 %%
 
 -define(CLIENT_ID_MAXLEN, 23).

--- a/include/rabbit_mqtt_frame.hrl
+++ b/include/rabbit_mqtt_frame.hrl
@@ -11,7 +11,7 @@
 %% The Original Code is RabbitMQ.
 %%
 %% The Initial Developer of the Original Code is GoPivotal, Inc.
-%% Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+%% Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 %%
 
 -define(PROTOCOL_NAMES,  [{3, "MQIsdp"}, {4, "MQTT"}]).

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DecommissionMqttNodeCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DecommissionMqttNodeCommand.erl
@@ -1,0 +1,77 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at https://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+-module('Elixir.RabbitMQ.CLI.Ctl.Commands.DecommissionMqttNodeCommand').
+
+-include("rabbit_mqtt.hrl").
+
+-behaviour('Elixir.RabbitMQ.CLI.CommandBehaviour').
+
+-export([scopes/0,
+         switches/0,
+         aliases/0,
+         usage/0,
+         usage_doc_guides/0,
+         banner/2,
+         validate/2,
+         merge_defaults/2,
+         run/2,
+         output/2,
+         description/0,
+         help_section/0]).
+
+scopes() -> [ctl, diagnostics].
+switches() -> [].
+aliases() -> [].
+
+description() -> <<"Decommissions MQTT cluster member used to track client ids">>.
+
+help_section() ->
+    {plugin, mqtt}.
+
+validate([], _Opts) ->
+    {validation_failure, not_enough_args};
+validate([_, _ | _], _Opts) ->
+    {validation_failure, too_many_args};
+validate([_], _) ->
+    ok.
+
+merge_defaults(Args, Opts) ->
+    {Args, Opts}.
+
+usage() ->
+    <<"decomission_mqtt_node <node>">>.
+
+usage_doc_guides() ->
+    [?MQTT_GUIDE_URL].
+
+run([Node], #{node := NodeName,
+              timeout := Timeout}) ->
+    case rabbit_misc:rpc_call(NodeName, rabbit_mqtt_collector, leave, [Node], Timeout) of
+        {badrpc, _} = Error ->
+            Error;
+        nodedown ->
+            list_to_binary(io_lib:format("Node ~p is down but has been successfully removed"
+                                         " from the cluster", [Node]));
+        Result ->
+            %% 'ok' or 'timeout'
+            %% TODO: Ra will timeout if the node is not a cluster member - should this be fixed??
+            Result
+    end.
+
+banner(_, _) -> <<"Decomissioning MQTT node used for client id tracking ...">>.
+
+output(Result, _Opts) ->
+    'Elixir.RabbitMQ.CLI.DefaultOutput':output(Result).

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DecommissionMqttNodeCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DecommissionMqttNodeCommand.erl
@@ -71,7 +71,7 @@ run([Node], #{node := NodeName,
             Result
     end.
 
-banner(_, _) -> <<"Decomissioning MQTT node used for client id tracking ...">>.
+banner(_, _) -> <<"Decommissions a node that serves MQTT clients ...">>.
 
 output(Result, _Opts) ->
     'Elixir.RabbitMQ.CLI.DefaultOutput':output(Result).

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DecommissionMqttNodeCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DecommissionMqttNodeCommand.erl
@@ -32,7 +32,7 @@
          description/0,
          help_section/0]).
 
-scopes() -> [ctl, diagnostics].
+scopes() -> [ctl].
 switches() -> [].
 aliases() -> [].
 
@@ -63,15 +63,15 @@ run([Node], #{node := NodeName,
         {badrpc, _} = Error ->
             Error;
         nodedown ->
-            list_to_binary(io_lib:format("Node ~s is down but has been successfully removed"
-                                         " from the cluster", [Node]));
+            {ok, list_to_binary(io_lib:format("Node ~s is down but has been successfully removed"
+                                         " from the cluster", [Node]))};
         Result ->
             %% 'ok' or 'timeout'
             %% TODO: Ra will timeout if the node is not a cluster member - should this be fixed??
             Result
     end.
 
-banner(_, _) -> <<"Decommissions a node that serves MQTT clients ...">>.
+banner([Node], _) -> list_to_binary(io:format("Removing node ~s from the list of MQTT nodes...", [Node])).
 
 output(Result, _Opts) ->
     'Elixir.RabbitMQ.CLI.DefaultOutput':output(Result).

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DecommissionMqttNodeCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DecommissionMqttNodeCommand.erl
@@ -71,7 +71,7 @@ run([Node], #{node := NodeName,
             Result
     end.
 
-banner([Node], _) -> list_to_binary(io:format("Removing node ~s from the list of MQTT nodes...", [Node])).
+banner([Node], _) -> list_to_binary(io_lib:format("Removing node ~s from the list of MQTT nodes...", [Node])).
 
 output(Result, _Opts) ->
     'Elixir.RabbitMQ.CLI.DefaultOutput':output(Result).

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DecommissionMqttNodeCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DecommissionMqttNodeCommand.erl
@@ -36,7 +36,7 @@ scopes() -> [ctl, diagnostics].
 switches() -> [].
 aliases() -> [].
 
-description() -> <<"Decommissions MQTT cluster member used to track client ids">>.
+description() -> <<"Removes cluster member and permanently deletes its cluster-wide MQTT state">>.
 
 help_section() ->
     {plugin, mqtt}.
@@ -52,7 +52,7 @@ merge_defaults(Args, Opts) ->
     {Args, Opts}.
 
 usage() ->
-    <<"decomission_mqtt_node <node>">>.
+    <<"decommission_mqtt_node <node>">>.
 
 usage_doc_guides() ->
     [?MQTT_GUIDE_URL].
@@ -63,7 +63,7 @@ run([Node], #{node := NodeName,
         {badrpc, _} = Error ->
             Error;
         nodedown ->
-            list_to_binary(io_lib:format("Node ~p is down but has been successfully removed"
+            list_to_binary(io_lib:format("Node ~s is down but has been successfully removed"
                                          " from the cluster", [Node]));
         Result ->
             %% 'ok' or 'timeout'

--- a/src/mqtt_machine.erl
+++ b/src/mqtt_machine.erl
@@ -86,7 +86,7 @@ apply(Meta, {leave, Node}, #state{client_ids = Ids} = State0) ->
     Effects = lists:foldl(fun (ClientId, Acc) ->
                           Pid = maps:get(ClientId, Ids),
                           [
-                            {demoonitor, process, Pid},
+                            {demonitor, process, Pid},
                             {mod_call, gen_server2, cast, [Pid, decommission_node]},
                             {mod_call, rabbit_log, debug,
                               ["MQTT will remove client ID '~s' from known "

--- a/src/mqtt_machine.erl
+++ b/src/mqtt_machine.erl
@@ -54,7 +54,7 @@ apply(Meta, {register, ClientId, Pid}, #machine_state{client_ids = Ids} = State0
               {Effects0, Ids}
         end,
     State = State0#machine_state{client_ids = maps:put(ClientId, Pid, Ids1)},
-    {State, ok, Effects ++ snapshot_effects(Meta, State)};
+    {State, ok, Effects};
 
 apply(Meta, {unregister, ClientId, Pid}, #machine_state{client_ids = Ids} = State0) ->
     State = case maps:find(ClientId, Ids) of

--- a/src/mqtt_machine.erl
+++ b/src/mqtt_machine.erl
@@ -103,9 +103,6 @@ apply(Meta, {leave, Node}, #machine_state{client_ids = Ids} = State0) ->
     State = State0#machine_state{client_ids = Ids1},
     {State, ok, Effects ++ snapshot_effects(Meta, State)};
 
-apply(Meta, list, #machine_state{client_ids = Ids} = State) ->
-    {State, maps:to_list(Ids), snapshot_effects(Meta, State)};
-
 apply(_Meta, Unknown, State) ->
     error_logger:error_msg("MQTT Raft state machine received unknown command ~p~n", [Unknown]),
     {State, {error, {unknown_command, Unknown}}, []}.

--- a/src/mqtt_machine.erl
+++ b/src/mqtt_machine.erl
@@ -41,7 +41,7 @@ init(_Conf) ->
 
 -spec apply(map(), command(), state()) ->
     {state(), reply(), ra_machine:effects()}.
-apply(Meta, {register, ClientId, Pid}, #machine_state{client_ids = Ids} = State0) ->
+apply(_Meta, {register, ClientId, Pid}, #machine_state{client_ids = Ids} = State0) ->
     {Effects, Ids1} =
         case maps:find(ClientId, Ids) of
             {ok, OldPid} when Pid =/= OldPid ->
@@ -99,7 +99,7 @@ apply(_Meta, {nodeup, Node}, State) ->
     Effects = [{monitor, process, Pid} || Pid <- all_pids(State), node(Pid) == Node],
     {State, ok, Effects};
 apply(_Meta, {nodedown, _Node}, State) ->
-    {State, ok}.
+    {State, ok};
 
 apply(Meta, {leave, Node}, #machine_state{client_ids = Ids} = State0) ->
     Ids1 = maps:filter(fun (_ClientId, Pid) -> node(Pid) =/= Node end, Ids),

--- a/src/mqtt_machine.erl
+++ b/src/mqtt_machine.erl
@@ -74,10 +74,10 @@ apply(Meta, {down, DownPid, _}, #state{client_ids = Ids} = State0) ->
                        end, Ids),
     State = State0#state{client_ids = Ids1},
     Delta = maps:keys(Ids) -- maps:keys(Ids1),
-    LogEffects = lists:map(fun(Id) ->
+    Effects = lists:map(fun(Id) ->
                   [{mod_call, rabbit_log, debug,
                     ["MQTT connection with client id '~s' failed", [Id]]}] end, Delta),
-    {State, ok, snapshot_effects(Meta, State) ++ LogEffects};
+    {State, ok, Effects ++ snapshot_effects(Meta, State)};
 
 apply(Meta, {leave, Node}, #state{client_ids = Ids} = State0) ->
     Ids1 = maps:filter(fun (_ClientId, Pid) -> node(Pid) =/= Node end, Ids),

--- a/src/mqtt_machine.erl
+++ b/src/mqtt_machine.erl
@@ -64,7 +64,13 @@ apply(Meta, {unregister, ClientId, Pid}, #machine_state{client_ids = Ids} = Stat
       {ok, _AnotherPid} -> State0;
       error             -> State0
     end,
-    {State, ok, [{demonitor, process, Pid}] ++ snapshot_effects(Meta, State)};
+    Effects0 = [{demonitor, process, Pid}],
+    %% snapshot only when the map has changed
+    Effects = case State of
+      State0 -> Effects0;
+      _      -> Effects0 ++ snapshot_effects(Meta, State)
+    end,
+    {State, ok, Effects};
 
 apply(Meta, {down, DownPid, _}, #machine_state{client_ids = Ids} = State0) ->
     Ids1 = maps:filter(fun (_ClientId, Pid) when Pid =:= DownPid ->

--- a/src/mqtt_node.erl
+++ b/src/mqtt_node.erl
@@ -1,0 +1,79 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at https://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+%%
+-module(mqtt_node).
+
+-export([start/0, node_id/0, leave/1]).
+
+-define(START_TIMEOUT, 100000).
+
+node_id() ->
+    node_id(node()).
+
+node_id(Node) ->
+    {mqtt_node, Node}.
+
+start() ->
+    Name = mqtt_node,
+    NodeId = node_id(),
+    Nodes = [{Name, N} || N <- rabbit_mnesia:cluster_nodes(all)] -- [NodeId],
+    Res = case ra_directory:uid_of(Name) of
+              undefined ->
+                  UId = ra:new_uid(ra_lib:to_binary(Name)),
+                  Conf = #{cluster_name => Name,
+                           id => NodeId,
+                           uid => UId,
+                           friendly_name => Name,
+                           initial_members => Nodes,
+                           log_init_args => #{uid => UId},
+                           tick_timeout => 5000,
+                           machine => {module, mqtt_machine, #{}}},
+                  ra:start_server(Conf);
+              _ ->
+                  ra:restart_server(NodeId)
+          end,
+    case Res of
+        ok ->
+            case Nodes of
+                [] -> ok;
+                [Member | _] -> ra:add_member(Member, NodeId)
+            end,
+            %% Trigger election.
+            %% This is required when we start a node for the first time.
+            %% Using default timeout because it supposed to reply fast.
+            ra:trigger_election(NodeId),
+            case ra:members(NodeId, ?START_TIMEOUT) of
+                {ok, _, _} ->
+                    ok;
+                {timeout, _} = Err ->
+                    rabbit_log:warning("Timeout waiting for mqtt cluster"),
+                    Err;
+                Err ->
+                    Err
+            end;
+        _ ->
+            Res
+    end.
+
+-spec leave(node()) -> 'ok' | 'timeout' | 'nodedown'.
+leave(Node) ->
+    NodeId = node_id(),
+    ToLeave = node_id(Node),
+    try
+        ra:leave_and_delete_server(NodeId, ToLeave)
+    catch
+        exit:{{nodedown, Node}, _} ->
+            nodedown
+    end.

--- a/src/mqtt_node.erl
+++ b/src/mqtt_node.erl
@@ -58,7 +58,7 @@ start() ->
                 {ok, _, _} ->
                     ok;
                 {timeout, _} = Err ->
-                    rabbit_log:warning("Timeout waiting for mqtt cluster"),
+                    rabbit_log:warning("MQTT: timed out contacting cluster peers"),
                     Err;
                 Err ->
                     Err

--- a/src/rabbit_mqtt_collector.erl
+++ b/src/rabbit_mqtt_collector.erl
@@ -16,6 +16,8 @@
 
 -module(rabbit_mqtt_collector).
 
+-include("mqtt_machine.hrl").
+
 -export([register/2, unregister/2, list/0, leave/1]).
 
 %%----------------------------------------------------------------------------
@@ -26,7 +28,10 @@ unregister(ClientId, Pid) ->
     run_ra_command({unregister, ClientId, Pid}).
 
 list() ->
-     run_ra_command(list).
+     NodeId = mqtt_node:node_id(),
+     QF = fun (#machine_state{client_ids = Ids}) -> maps:to_list(Ids) end,
+     {ok, {_, Ids}, _} = ra:leader_query(NodeId, QF),
+     Ids.
 
 leave(NodeBin) ->
     Node = binary_to_atom(NodeBin, utf8),

--- a/src/rabbit_mqtt_collector.erl
+++ b/src/rabbit_mqtt_collector.erl
@@ -11,91 +11,33 @@
 %% The Original Code is RabbitMQ.
 %%
 %% The Initial Developer of the Original Code is GoPivotal, Inc.
-%% Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+%% Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 %%
 
 -module(rabbit_mqtt_collector).
 
--behaviour(gen_server).
-
--export([start_link/0, register/2, unregister/2, list/0]).
-
--export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
-
--record(state, {client_ids}).
-
--define(SERVER, ?MODULE).
+-export([register/2, unregister/2, list/0, leave/1]).
 
 %%----------------------------------------------------------------------------
-
-start_link() ->
-    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
-
 register(ClientId, Pid) ->
-    gen_server:call(rabbit_mqtt_collector, {register, ClientId, Pid}, infinity).
+    run_ra_command({register, ClientId, Pid}).
 
 unregister(ClientId, Pid) ->
-    gen_server:call(rabbit_mqtt_collector, {unregister, ClientId, Pid}, infinity).
+    run_ra_command({unregister, ClientId, Pid}).
 
 list() ->
-    gen_server:call(rabbit_mqtt_collector, list).
+     run_ra_command(list).
+
+leave(NodeBin) ->
+    Node = binary_to_atom(NodeBin, utf8),
+    run_ra_command({leave, Node}),
+    mqtt_node:leave(Node).
 
 %%----------------------------------------------------------------------------
-
-init([]) ->
-    {ok, #state{client_ids = #{}}}. % clientid -> {pid, monitor}
-
-%%--------------------------------------------------------------------------
-
-handle_call({register, ClientId, Pid}, _From,
-            State = #state{client_ids = Ids}) ->
-    Ids1 = case maps:find(ClientId, Ids) of
-               {ok, {OldPid, MRef}} when Pid =/= OldPid ->
-                   catch gen_server2:cast(OldPid, duplicate_id),
-                   erlang:demonitor(MRef),
-                   maps:remove(ClientId, Ids);
-               error ->
-                   Ids
-           end,
-    Ids2 = maps:put(ClientId, {Pid, erlang:monitor(process, Pid)}, Ids1),
-    {reply, ok, State#state{client_ids = Ids2}};
-
-handle_call({unregister, ClientId, Pid}, _From, State = #state{client_ids = Ids}) ->
-    {Reply, Ids1} = case maps:find(ClientId, Ids) of
-                        {ok, {Pid, MRef}} -> erlang:demonitor(MRef),
-                                             {ok, maps:remove(ClientId, Ids)};
-                        _                 -> {ok, Ids}
-                    end,
-    {reply, Reply, State#state{ client_ids = Ids1 }};
-
-handle_call(list, _From, State = #state{client_ids = Ids}) ->
-    {reply, maps:to_list(Ids), State};
-
-handle_call(Msg, _From, State) ->
-    {stop, {unhandled_call, Msg}, State}.
-
-handle_cast(Msg, State) ->
-    {stop, {unhandled_cast, Msg}, State}.
-
-handle_info({'EXIT', _, {shutdown, closed}}, State) ->
-    {stop, {shutdown, closed}, State};
-
-handle_info({'DOWN', MRef, process, DownPid, _Reason},
-            State = #state{client_ids = Ids}) ->
-    Ids1 = maps:filter(fun (ClientId, {Pid, M})
-                           when Pid =:= DownPid, MRef =:= M ->
-                               rabbit_log_connection:warning(
-                                              "MQTT disconnect from ~p~n",
-                                              [ClientId]),
-                               false;
-                           (_, _) ->
-                               true
-                       end, Ids),
-    {noreply, State #state{ client_ids = Ids1 }}.
-
-terminate(_Reason, _State) ->
-    ok.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+-spec run_ra_command(term()) -> term() | {error, term()}.
+run_ra_command(RaCommand) ->
+    NodeId = mqtt_node:node_id(),
+    case ra:process_command(NodeId, RaCommand) of
+        {ok, Result, _} -> Result;
+        _ = Error -> Error
+    end.

--- a/src/rabbit_mqtt_reader.erl
+++ b/src/rabbit_mqtt_reader.erl
@@ -111,6 +111,14 @@ handle_cast(duplicate_id,
                  [rabbit_mqtt_processor:info(client_id, PState), ConnName]),
     {stop, {shutdown, duplicate_id}, State};
 
+handle_cast(decommission_node,
+            State = #state{ proc_state = PState,
+                            conn_name  = ConnName }) ->
+    rabbit_log_connection:warning("MQTT disconnecting client id ~p (~p) as node is about"
+                                  " to be decommissioned~n",
+                 [rabbit_mqtt_processor:info(client_id, PState), ConnName]),
+    {stop, {shutdown, decommission_node}, State};
+
 handle_cast(Msg, State) ->
     {stop, {mqtt_unexpected_cast, Msg}, State}.
 

--- a/src/rabbit_mqtt_reader.erl
+++ b/src/rabbit_mqtt_reader.erl
@@ -107,16 +107,16 @@ handle_call(Msg, From, State) ->
 handle_cast(duplicate_id,
             State = #state{ proc_state = PState,
                             conn_name  = ConnName }) ->
-    rabbit_log_connection:warning("MQTT disconnecting duplicate client id ~p (~p)~n",
-                 [rabbit_mqtt_processor:info(client_id, PState), ConnName]),
+    rabbit_log_connection:warning("MQTT disconnecting client ~p with duplicate id '~s'~n",
+                 [ConnName, rabbit_mqtt_processor:info(client_id, PState)]),
     {stop, {shutdown, duplicate_id}, State};
 
 handle_cast(decommission_node,
             State = #state{ proc_state = PState,
                             conn_name  = ConnName }) ->
-    rabbit_log_connection:warning("MQTT disconnecting client id ~p (~p) as node is about"
+    rabbit_log_connection:warning("MQTT disconnecting client ~p with id '~s' as its node is about"
                                   " to be decommissioned~n",
-                 [rabbit_mqtt_processor:info(client_id, PState), ConnName]),
+                 [ConnName, rabbit_mqtt_processor:info(client_id, PState)]),
     {stop, {shutdown, decommission_node}, State};
 
 handle_cast(Msg, State) ->
@@ -264,8 +264,9 @@ log_tls_alert(Alert, ConnStr) ->
     rabbit_log_connection:error("MQTT detected TLS upgrade error on ~s: alert ~s~n",
        [ConnStr, Alert]).
 
-log_new_connection(#state{conn_name = ConnStr}) ->
-    rabbit_log_connection:info("accepting MQTT connection ~p (~s)~n", [self(), ConnStr]).
+log_new_connection(#state{conn_name = ConnStr, proc_state = PState}) ->
+    rabbit_log_connection:info("accepting MQTT connection ~p (~s, client id: ~s)~n",
+                               [self(), ConnStr, rabbit_mqtt_processor:info(client_id, PState)]).
 
 process_received_bytes(<<>>, State = #state{proc_state = ProcState,
                                             received_connect_frame = false}) ->

--- a/src/rabbit_mqtt_sup.erl
+++ b/src/rabbit_mqtt_sup.erl
@@ -38,10 +38,7 @@ init([{Listeners, SslListeners0}]) ->
                      end}
           end,
     {ok, {{one_for_all, 10, 10},
-          [{collector,
-            {rabbit_mqtt_collector, start_link, []},
-            transient, ?WORKER_WAIT, worker, [rabbit_mqtt_collector]},
-           {rabbit_mqtt_retainer_sup,
+          [{rabbit_mqtt_retainer_sup,
             {rabbit_mqtt_retainer_sup, start_link, [{local, rabbit_mqtt_retainer_sup}]},
              transient, ?SUPERVISOR_WAIT, supervisor, [rabbit_mqtt_retainer_sup]} |
            listener_specs(fun tcp_listener_spec/1,

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -1,0 +1,130 @@
+-module(cluster_SUITE).
+-compile([export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+all() ->
+    [
+      {group, non_parallel_tests}
+    ].
+
+groups() ->
+    [
+      {non_parallel_tests, [], [
+                                nodedown,
+                                decommission_node
+                               ]}
+    ].
+
+suite() ->
+    [{timetrap, {seconds, 60}}].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+merge_app_env(Config) ->
+    rabbit_ct_helpers:merge_app_env(Config,
+                                    {rabbit, [
+                                              {collect_statistics, basic},
+                                              {collect_statistics_interval, 100}
+                                             ]}).
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_group(_, Config) ->
+    Config.
+
+end_per_group(_, Config) ->
+    Config.
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Testcase},
+        {rmq_extra_tcp_ports, [tcp_port_mqtt_extra,
+                               tcp_port_mqtt_tls_extra]},
+        {rmq_nodes_clustered, true},
+        {rmq_nodes_count, 3}
+      ]),
+    rabbit_ct_helpers:run_setup_steps(Config1,
+      [ fun merge_app_env/1 ] ++
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+%% -------------------------------------------------------------------
+%% Testsuite cases
+%% -------------------------------------------------------------------
+
+nodedown(Config) ->
+    P = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    {ok, C} = emqttc:start_link([{host, "localhost"},
+                                 {port, P},
+                                 {client_id, <<"simpleClient">>},
+                                 {proto_ver, 3},
+                                 {logger, info},
+                                 {puback_timeout, 1}]),
+    unlink(C),
+    MRef = erlang:monitor(process, C),
+    emqttc:subscribe(C, <<"TopicA">>, qos0),
+    emqttc:publish(C, <<"TopicA">>, <<"Payload">>),
+    expect_publishes(<<"TopicA">>, [<<"Payload">>]),
+
+    [_] = rabbit_ct_broker_helpers:rpc(Config, 1, rabbit_mqtt_collector, list, []),
+    ok = rabbit_ct_broker_helpers:stop_node(Config, Server),
+    receive
+        {'DOWN', MRef, _, _, _} ->
+            ok
+    after
+        30000 ->
+            exit(missing_down_message)
+    end,
+    [] = rabbit_ct_broker_helpers:rpc(Config, 1, rabbit_mqtt_collector, list, []).
+
+decommission_node(Config) ->
+    P = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    {ok, C} = emqttc:start_link([{host, "localhost"},
+                                 {port, P},
+                                 {client_id, <<"simpleClient">>},
+                                 {proto_ver, 3},
+                                 {logger, info},
+                                 {puback_timeout, 1}]),
+    unlink(C),
+    MRef = erlang:monitor(process, C),
+    emqttc:subscribe(C, <<"TopicA">>, qos0),
+    emqttc:publish(C, <<"TopicA">>, <<"Payload">>),
+    expect_publishes(<<"TopicA">>, [<<"Payload">>]),
+
+    [_] = rabbit_ct_broker_helpers:rpc(Config, 1, rabbit_mqtt_collector, list, []),
+    {ok, _} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["decommission_mqtt_node", Server]),
+    receive
+        {'DOWN', MRef, _, _, _} ->
+            ok
+    after
+        30000 ->
+            exit(missing_down_message)
+    end,
+    [] = rabbit_ct_broker_helpers:rpc(Config, 1, rabbit_mqtt_collector, list, []).
+
+expect_publishes(_Topic, []) -> ok;
+expect_publishes(Topic, [Payload|Rest]) ->
+    receive
+        {publish, Topic, Payload} -> expect_publishes(Topic, Rest)
+        after 5000 ->
+            throw({publish_not_delivered, Payload})
+    end.

--- a/test/java_SUITE.erl
+++ b/test/java_SUITE.erl
@@ -58,7 +58,9 @@ init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
     Config1 = rabbit_ct_helpers:set_config(Config, [
         {rmq_nodename_suffix, ?MODULE},
-        {rmq_certspwd, "bunnychow"}
+        {rmq_certspwd, "bunnychow"},
+        {rmq_nodes_clustered, true},
+        {rmq_nodes_count, 2}
       ]),
     rabbit_ct_helpers:run_setup_steps(Config1,
       [ fun merge_app_env/1 ] ++
@@ -105,11 +107,13 @@ end_per_testcase(Testcase, Config) ->
 java(Config) ->
     CertsDir = rabbit_ct_helpers:get_config(Config, rmq_certsdir),
     MqttPort = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
+    MqttPort2 = rabbit_ct_broker_helpers:get_node_config(Config, 1, tcp_port_mqtt),
     MqttSslPort = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt_tls),
     AmqpPort = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),
     os:putenv("SSL_CERTS_DIR", CertsDir),
     os:putenv("MQTT_SSL_PORT", erlang:integer_to_list(MqttSslPort)),
     os:putenv("MQTT_PORT", erlang:integer_to_list(MqttPort)),
+    os:putenv("MQTT_PORT_2", erlang:integer_to_list(MqttPort2)),
     os:putenv("AMQP_PORT", erlang:integer_to_list(AmqpPort)),
     DataDir = rabbit_ct_helpers:get_config(Config, data_dir),
     MakeResult = rabbit_ct_helpers:make(Config, DataDir, ["tests"]),

--- a/test/java_SUITE_data/Makefile
+++ b/test/java_SUITE_data/Makefile
@@ -5,6 +5,7 @@ MVN_FLAGS += -Ddeps.dir="$(abspath $(DEPS_DIR))" \
 			 -Dcerts.dir=$(SSL_CERTS_DIR) \
 			 -Dmqtt.ssl.port=$(MQTT_SSL_PORT) \
 			 -Dmqtt.port=$(MQTT_PORT) \
+			 -Dmqtt.port.2=$(MQTT_PORT_2) \
 			 -Damqp.port=$(AMQP_PORT)
 
 .PHONY: deps tests clean distclean

--- a/test/java_SUITE_data/pom.xml
+++ b/test/java_SUITE_data/pom.xml
@@ -57,6 +57,7 @@
               <certs.dir>${certs.dir}</certs.dir>
               <mqtt.ssl.port>${mqtt.ssl.port}</mqtt.ssl.port>
               <mqtt.port>${mqtt.port}</mqtt.port>
+              <mqtt.port.2>${mqtt.port.2}</mqtt.port.2>
               <amqp.port>${amqp.port}</amqp.port>
 
               <test-keystore.ca>${test-keystore.ca}</test-keystore.ca>

--- a/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/MqttTest.java
+++ b/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/MqttTest.java
@@ -52,6 +52,7 @@ public class MqttTest implements MqttCallback {
 
     private final String host = "localhost";
     private final String brokerUrl = "tcp://" + host + ":" + getPort();
+    private final String brokerTwoUrl = "tcp://" + host + ":" + getSecondPort();
     private String clientId;
     private String clientId2;
     private MqttClient client;
@@ -74,6 +75,12 @@ public class MqttTest implements MqttCallback {
 
     private static int getPort() {
         Object port = System.getProperty("mqtt.port", "1883");
+        Assert.assertNotNull(port);
+        return Integer.parseInt(port.toString());
+    }
+
+    private static int getSecondPort() {
+        Object port = System.getProperty("mqtt.port.2", "1883");
         Assert.assertNotNull(port);
         return Integer.parseInt(port.toString());
     }
@@ -509,6 +516,14 @@ public class MqttTest implements MqttCallback {
     @Test public void multipleClientIds() throws MqttException, InterruptedException {
         client.connect(conOpt);
         client2 = new MqttClient(brokerUrl, clientId, null);
+        client2.connect(conOpt);
+        waitAtMost(timeout).until(isClientConnected(),equalTo(false));
+        client2.disconnect();
+    }
+
+    @Test public void multipleClusterClientIds() throws MqttException, InterruptedException {
+        client.connect(conOpt);
+        client2 = new MqttClient(brokerTwoUrl, clientId, null);
         client2.connect(conOpt);
         waitAtMost(timeout).until(isClientConnected(),equalTo(false));
         client2.disconnect();

--- a/test/reader_SUITE.erl
+++ b/test/reader_SUITE.erl
@@ -138,7 +138,7 @@ stats(Config) ->
     emqttc:unsubscribe(C, [<<"TopicA">>]),
     timer:sleep(1000), %% Wait for stats to be emitted, which it does every 100ms
     %% Retrieve the connection Pid
-    [{_, {Reader, _}}] = rpc(Config, rabbit_mqtt_collector, list, []),
+    [{_, Reader}] = rpc(Config, rabbit_mqtt_collector, list, []),
     [{_, Pid}] = rpc(Config, rabbit_mqtt_reader, info, [Reader, [connection]]),
     %% Verify the content of the metrics, garbage_collection must be present
     [{Pid, Props}] = rpc(Config, ets, lookup, [connection_metrics, Pid]),


### PR DESCRIPTION
Uses a ra cluster to keep the client id tracking information - in
the state of the ra machine.

If nodes are decommissioned from the RMQ cluster, the command
decommission_mqtt_node must be invoked first to disconnect the clients
on that node and remove the node from the ra cluster.

[#135330629]

## Types of Changes
- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
