### PR TITLE
Client ID tracker node should try to rejoin the cluster for a period of time

### DIFF
--- a/src/mqtt_node.erl
+++ b/src/mqtt_node.erl
@@ -34,7 +34,7 @@ start() ->
     Res = case ra_directory:uid_of(Name) of
               undefined ->
                   UId = ra:new_uid(ra_lib:to_binary(Name)),
-                  Timeout = application:get_env(kernel, net_ticktime, 60000) + 5000,
+                  Timeout = application:get_env(kernel, net_ticktime, 60) + 5,
                   Conf = #{cluster_name => Name,
                            id => NodeId,
                            uid => UId,
@@ -63,11 +63,11 @@ start() ->
         _  -> Res
     end.
 
-join_peers(NodeId, [NodeId]) ->
+join_peers(NodeId, []) ->
     ok;
 join_peers(NodeId, Nodes) ->
     join_peers(NodeId, Nodes, 100).
-join_peers(NodeId, [NodeId], _RetriesLeft) ->
+join_peers(NodeId, [], _RetriesLeft) ->
     ok;
 join_peers(_NodeId, _Nodes, RetriesLeft) when RetriesLeft =:= 0 ->
     rabbit_log:error("MQTT: exhausted all attempts while trying to rejoin cluster peers");

--- a/src/mqtt_node.erl
+++ b/src/mqtt_node.erl
@@ -34,13 +34,14 @@ start() ->
     Res = case ra_directory:uid_of(Name) of
               undefined ->
                   UId = ra:new_uid(ra_lib:to_binary(Name)),
+                  Timeout = application:get_env(kernel, net_ticktime, 60000) + 5000,
                   Conf = #{cluster_name => Name,
                            id => NodeId,
                            uid => UId,
                            friendly_name => Name,
                            initial_members => Nodes,
                            log_init_args => #{uid => UId},
-                           tick_timeout => 5000,
+                           tick_timeout => Timeout,
                            machine => {module, mqtt_machine, #{}}},
                   ra:start_server(Conf),
                   %% Trigger an election.

--- a/src/mqtt_node.erl
+++ b/src/mqtt_node.erl
@@ -18,6 +18,7 @@
 -export([start/0, node_id/0, leave/1]).
 
 -define(START_TIMEOUT, 100000).
+-define(RETRY_INTERVAL, 5000).
 
 node_id() ->
     node_id(node()).
@@ -41,31 +42,46 @@ start() ->
                            log_init_args => #{uid => UId},
                            tick_timeout => 5000,
                            machine => {module, mqtt_machine, #{}}},
-                  ra:start_server(Conf);
+                  ra:start_server(Conf),
+                  %% Trigger an election.
+                  %% This is required when we start a node for the first time.
+                  %% Using default timeout because it supposed to reply fast.
+                  case Nodes of
+                    [NodeId] ->
+                      ra:trigger_election(NodeId);
+                    _        -> ok
+                  end;
               _ ->
                   ra:restart_server(NodeId)
           end,
     case Res of
         ok ->
-            case Nodes of
-                [] -> ok;
-                [Member | _] -> ra:add_member(Member, NodeId)
-            end,
-            %% Trigger election.
-            %% This is required when we start a node for the first time.
-            %% Using default timeout because it supposed to reply fast.
-            ra:trigger_election(NodeId),
-            case ra:members(NodeId, ?START_TIMEOUT) of
-                {ok, _, _} ->
-                    ok;
-                {timeout, _} = Err ->
-                    rabbit_log:warning("MQTT: timed out contacting cluster peers"),
-                    Err;
-                Err ->
-                    Err
+          spawn(fun() -> join_peers(NodeId, Nodes) end),
+          ok;
+        _  -> Res
+    end.
+
+join_peers(NodeId, [NodeId]) ->
+    ok;
+join_peers(NodeId, Nodes) ->
+    join_peers(NodeId, Nodes, 100).
+join_peers(NodeId, [NodeId], _RetriesLeft) ->
+    ok;
+join_peers(_NodeId, _Nodes, RetriesLeft) when RetriesLeft =:= 0 ->
+    rabbit_log:error("MQTT: exhausted all attempts while trying to rejoin cluster peers");
+join_peers(NodeId, Nodes, RetriesLeft) ->
+    case ra:members(Nodes, ?START_TIMEOUT) of
+        {ok, Members, _} ->
+            case lists:member(NodeId, Members) of
+                true  -> ok;
+                false -> ra:add_member(Members, NodeId)
             end;
-        _ ->
-            Res
+        {timeout, _} ->
+            rabbit_log:debug("MQTT: timed out contacting cluster peers, %s retries left", [RetriesLeft]),
+            timer:sleep(?RETRY_INTERVAL),
+            join_peers(NodeId, Nodes, RetriesLeft - 1);
+        Err ->
+            Err
     end.
 
 -spec leave(node()) -> 'ok' | 'timeout' | 'nodedown'.

--- a/src/mqtt_node.erl
+++ b/src/mqtt_node.erl
@@ -47,7 +47,8 @@ start() ->
                   %% This is required when we start a node for the first time.
                   %% Using default timeout because it supposed to reply fast.
                   case Nodes of
-                    [NodeId] ->
+                    [] ->
+                      rabbit_log:info("MQTT: observed no cluster peers that support client ID tracking, assuming we should start a new Raft leader election"),
                       ra:trigger_election(NodeId);
                     _        -> ok
                   end;

--- a/src/mqtt_node.erl
+++ b/src/mqtt_node.erl
@@ -63,11 +63,11 @@ start() ->
         _  -> Res
     end.
 
-join_peers(NodeId, []) ->
+join_peers(_NodeId, []) ->
     ok;
 join_peers(NodeId, Nodes) ->
     join_peers(NodeId, Nodes, 100).
-join_peers(NodeId, [], _RetriesLeft) ->
+join_peers(_NodeId, [], _RetriesLeft) ->
     ok;
 join_peers(_NodeId, _Nodes, RetriesLeft) when RetriesLeft =:= 0 ->
     rabbit_log:error("MQTT: exhausted all attempts while trying to rejoin cluster peers");

--- a/src/rabbit_mqtt_collector.erl
+++ b/src/rabbit_mqtt_collector.erl
@@ -30,8 +30,10 @@ unregister(ClientId, Pid) ->
 list() ->
      NodeId = mqtt_node:node_id(),
      QF = fun (#machine_state{client_ids = Ids}) -> maps:to_list(Ids) end,
-     {ok, {_, Ids}, _} = ra:leader_query(NodeId, QF),
-     Ids.
+     case ra:leader_query(NodeId, QF) of
+       {ok, {_, Ids}, _} -> Ids;
+       {timeout, _}      -> []
+     end.
 
 leave(NodeBin) ->
     Node = binary_to_atom(NodeBin, utf8),

--- a/src/rabbit_mqtt_reader.erl
+++ b/src/rabbit_mqtt_reader.erl
@@ -298,26 +298,26 @@ process_received_bytes(Bytes,
                                     connection = ConnPid });
                 %% PUBLISH and more
                 {error, unauthorized = Reason, ProcState1} ->
-                    rabbit_log_connection:info("MQTT connection ~s is closing due to an authorization failure~n", [ConnStr]),
+                    rabbit_log_connection:error("MQTT connection ~s is closing due to an authorization failure~n", [ConnStr]),
                     {stop, {shutdown, Reason}, pstate(State, ProcState1)};
                 %% CONNECT frames only
                 {error, unauthenticated = Reason, ProcState1} ->
-                    rabbit_log_connection:info("MQTT connection ~s is closing due to an authentication failure~n", [ConnStr]),
+                    rabbit_log_connection:error("MQTT connection ~s is closing due to an authentication failure~n", [ConnStr]),
                     {stop, {shutdown, Reason}, pstate(State, ProcState1)};
                 %% CONNECT frames only
                 {error, invalid_client_id = Reason, ProcState1} ->
-                    rabbit_log_connection:info("MQTT cannot accept connection ~s: client uses an invalid ID~n", [ConnStr]),
+                    rabbit_log_connection:error("MQTT cannot accept connection ~s: client uses an invalid ID~n", [ConnStr]),
                     {stop, {shutdown, Reason}, pstate(State, ProcState1)};
                 %% CONNECT frames only
                 {error, unsupported_protocol_version = Reason, ProcState1} ->
-                    rabbit_log_connection:info("MQTT cannot accept connection ~s: incompatible protocol version~n", [ConnStr]),
+                    rabbit_log_connection:error("MQTT cannot accept connection ~s: incompatible protocol version~n", [ConnStr]),
                     {stop, {shutdown, Reason}, pstate(State, ProcState1)};
                 {error, unavailable = Reason, ProcState1} ->
-                    rabbit_log_connection:info("MQTT cannot accept connection ~s due to an internal error or unavailable component~n",
+                    rabbit_log_connection:error("MQTT cannot accept connection ~s due to an internal error or unavailable component~n",
                         [ConnStr]),
                     {stop, {shutdown, Reason}, pstate(State, ProcState1)};
                 {error, Reason, ProcState1} ->
-                    rabbit_log_connection:info("MQTT protocol error on connection ~s: ~p~n",
+                    rabbit_log_connection:error("MQTT protocol error on connection ~s: ~p~n",
                         [ConnStr, Reason]),
                     {stop, {shutdown, Reason}, pstate(State, ProcState1)};
                 {error, Error} ->


### PR DESCRIPTION
## Proposed Changes

On plugin startup, client ID tracker node should try to rejoin the cluster for a period of time (currently 500 seconds, the value is not particularly scientific). This means that a cluster can lose the majority of nodes for a period of time and still recover when a majority rejoins.
Restarting the plugin will renew the attempts.

While investigating a failure introduced in the original version of this PR
I've noticed a few curious decisions in `process_frame/3`, so I refactored it a bit
and improved logging. 

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #200)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

I've paired wiith @kjnilsson on the Ra part of this PR.

Closes #200.