### PR TITLE
Do not reach out to all nodes when listing connections

### DIFF
--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListMqttConnectionsCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListMqttConnectionsCommand.erl
@@ -76,7 +76,10 @@ run(Args, #{node := NodeName,
         true  -> ?INFO_ITEMS;
         false -> 'Elixir.RabbitMQ.CLI.Ctl.InfoKeys':prepare_info_keys(Args)
     end,
-    Nodes = 'Elixir.RabbitMQ.CLI.Core.Helpers':nodes_in_cluster(NodeName),
+
+    %% a node uses the Raft-based collector to list connections, which knows about all connections in the cluster
+    %% so no need to reach out to all the nodes
+    Nodes = [NodeName],
 
     'Elixir.RabbitMQ.CLI.Ctl.RpcStream':receive_list_items(
         NodeName,

--- a/test/command_SUITE.erl
+++ b/test/command_SUITE.erl
@@ -43,7 +43,9 @@ init_per_suite(Config) ->
     Config1 = rabbit_ct_helpers:set_config(Config, [
         {rmq_nodename_suffix, ?MODULE},
         {rmq_extra_tcp_ports, [tcp_port_mqtt_extra,
-                               tcp_port_mqtt_tls_extra]}
+                               tcp_port_mqtt_tls_extra]},
+        {rmq_nodes_clustered, true},
+        {rmq_nodes_count, 3}
       ]),
     rabbit_ct_helpers:run_setup_steps(Config1,
       rabbit_ct_broker_helpers:setup_steps() ++


### PR DESCRIPTION
The way connections are listed already contains all the connections, so
there is no need to reach out to all cluster nodes and aggregate the
results, as it results in duplicate lines.

The command test now uses a cluster to make sure connections are listed
properly in a cluster.

[#167639960]

Fixes #202