### PR TITLE
Downgrade QoS 2 to QoS 1 when sending Last Will

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 # vim:sw=2:et:
 
+dist: bionic
+
 sudo: false
 language: erlang
 notifications:
@@ -11,14 +13,14 @@ notifications:
 addons:
   apt:
     sources:
-      - sourceline: deb https://packages.erlang-solutions.com/ubuntu trusty contrib
+      - sourceline: deb https://packages.erlang-solutions.com/ubuntu bionic contrib
         key_url: https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
     packages:
       - awscli
       # Use Elixir from Erlang Solutions. The provided Elixir is
       # installed with kiex but is old. We also can't use kiex to
       # install a newer one because of GitHub API rate limiting.
-      - elixir=1.8.1-1
+      - elixir=1.9.3-1
       - maven
 cache:
   apt: true
@@ -29,6 +31,7 @@ env:
 
 otp_release:
   - "21.3"
+  - "22.1"
 
 before_script:
   # The checkout made by Travis is a "detached HEAD" and branches
@@ -46,7 +49,7 @@ before_script:
   - |
     echo YES | kiex implode
     elixir --version
-    elixir --version | grep -q 'Elixir 1.8.1'
+    elixir --version | grep -q 'Elixir 1.9'
 
 script:
   - make xref

--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -735,7 +735,8 @@ supported_subs_qos(?QOS_1) -> ?QOS_1;
 supported_subs_qos(?QOS_2) -> ?QOS_1.
 
 delivery_mode(?QOS_0) -> 1;
-delivery_mode(?QOS_1) -> 2.
+delivery_mode(?QOS_1) -> 2;
+delivery_mode(?QOS_2) -> 2.
 
 %% different qos subscriptions are received in different queues
 %% with appropriate durability and timeout arguments

--- a/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/MqttTest.java
+++ b/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/MqttTest.java
@@ -808,7 +808,7 @@ public class MqttTest implements MqttCallback {
     }
 
     @Test public void lastWillDowngradesQoS2(TestInfo info) throws Exception {
-        String lastWillTopic = "last-will-downgrades-qos";
+        String lastWillTopic = "test-topic-will-downgrades-qos";
 
         MqttConnectOptions client2Opts = new TestMqttConnectOptions();
         MqttClient client2 = newConnectedClient(info, client2Opts);
@@ -842,7 +842,7 @@ public class MqttTest implements MqttCallback {
 
         MqttConnectOptions clientOpts = new TestMqttConnectOptions();
 
-        MqttClient client = newClient("last-will-downgrades-qos");
+        MqttClient client = newClient("test-topic-will-downgrades-qos");
         clientOpts.setSocketFactory(testFactory);
         MqttTopic willTopic = client.getTopic(lastWillTopic);
         clientOpts.setWill(willTopic, payload, 2, false);


### PR DESCRIPTION
## Proposed Changes

QoS 2 was not downgraded to QoS 1 correctly when Last Will messages were sent.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #214)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #214.