### PR TITLE
Make interactions with Ra async

### DIFF
--- a/include/rabbit_mqtt.hrl
+++ b/include/rabbit_mqtt.hrl
@@ -54,7 +54,8 @@
                       send_fun,
                       peer_addr,
                       mqtt2amqp_fun,
-                      amqp2mqtt_fun }).
+                      amqp2mqtt_fun,
+                      register_state }).
 
 -record(auth_state, {username,
                      user,

--- a/src/rabbit_mqtt_collector.erl
+++ b/src/rabbit_mqtt_collector.erl
@@ -18,33 +18,80 @@
 
 -include("mqtt_machine.hrl").
 
--export([register/2, unregister/2, list/0, leave/1]).
+-export([register/2, register/3, unregister/2, list/0, leave/1]).
 
 %%----------------------------------------------------------------------------
+-spec register(term(), pid()) -> {ok, reference()} | {error, term()}.
 register(ClientId, Pid) ->
-    run_ra_command({register, ClientId, Pid}).
+    {ClusterName, _} = NodeId = mqtt_node:node_id(),
+    case ra_leaderboard:lookup_leader(ClusterName) of
+        undefined ->
+            case ra:members(NodeId) of
+                {ok, _, Leader} ->
+                    register(Leader, ClientId, Pid);
+                 _ = Error ->
+                    Error
+            end;
+        Leader ->
+            register(Leader, ClientId, Pid)
+    end.
+
+-spec register(ra:server_id(), term(), pid()) ->
+    {ok, reference()} | {error, term()}.
+register(ServerId, ClientId, Pid) ->
+    Corr = make_ref(),
+    send_ra_command(ServerId, {register, ClientId, Pid}, Corr),
+    erlang:send_after(5000, self(), {ra_event, undefined, register_timeout}),
+    {ok, Corr}.
 
 unregister(ClientId, Pid) ->
-    run_ra_command({unregister, ClientId, Pid}).
+    {ClusterName, _} = mqtt_node:node_id(),
+    case ra_leaderboard:lookup_leader(ClusterName) of
+        undefined ->
+            ok;
+        Leader ->
+            send_ra_command(Leader, {unregister, ClientId, Pid}, no_correlation)
+    end.
 
 list() ->
-     NodeIds = mqtt_node:all_node_ids(),
+    {ClusterName, _} = mqtt_node:node_id(),
      QF = fun (#machine_state{client_ids = Ids}) -> maps:to_list(Ids) end,
-     case ra:leader_query(NodeIds, QF) of
-       {ok, {_, Ids}, _} -> Ids;
-       {timeout, _}      -> []
-     end.
+    case ra_leaderboard:lookup_leader(ClusterName) of
+        undefined ->
+            NodeIds = mqtt_node:all_node_ids(),
+            case ra:leader_query(NodeIds, QF) of
+                {ok, {_, Ids}, _} -> Ids;
+                {timeout, _}      ->
+                    rabbit_log:debug("~s:list/0 leader query timed out",
+                                     [?MODULE]),
+                    []
+            end;
+        Leader ->
+            case ra:leader_query(Leader, QF) of
+                {ok, {_, Ids}, _} -> Ids;
+                {error, _} ->
+                    [];
+                {timeout, _}      ->
+                    rabbit_log:debug("~s:list/0 leader query timed out",
+                                     [?MODULE]),
+                    []
+            end
+    end.
 
 leave(NodeBin) ->
     Node = binary_to_atom(NodeBin, utf8),
-    run_ra_command({leave, Node}),
+    ServerId = mqtt_node:node_id(),
+    run_ra_command(ServerId, {leave, Node}),
     mqtt_node:leave(Node).
 
 %%----------------------------------------------------------------------------
--spec run_ra_command(term()) -> term() | {error, term()}.
-run_ra_command(RaCommand) ->
-    NodeId = mqtt_node:node_id(),
-    case ra:process_command(NodeId, RaCommand) of
+-spec run_ra_command(term(), term()) -> term() | {error, term()}.
+run_ra_command(ServerId, RaCommand) ->
+    case ra:process_command(ServerId, RaCommand) of
         {ok, Result, _} -> Result;
         _ = Error -> Error
     end.
+
+-spec send_ra_command(term(), term(), term()) -> ok.
+send_ra_command(ServerId, RaCommand, Correlation) ->
+    ok = ra:pipeline_command(ServerId, RaCommand, Correlation, normal).

--- a/src/rabbit_mqtt_reader.erl
+++ b/src/rabbit_mqtt_reader.erl
@@ -190,6 +190,13 @@ handle_info(keepalive_timeout, State = #state {conn_name = ConnStr,
 handle_info(emit_stats, State) ->
     {noreply, emit_stats(State), hibernate};
 
+handle_info({ra_event, _From, Evt},
+            #state{proc_state = PState} = State) ->
+    %% handle applied event to ensure registration command actually got applied
+    %% handle not_leader notification in case we send the command to a non-leader
+    PState1 = rabbit_mqtt_processor:handle_ra_event(Evt, PState),
+    {noreply, State#state{proc_state = PState1}, hibernate};
+
 handle_info(Msg, State) ->
     {stop, {mqtt_unexpected_msg, Msg}, State}.
 


### PR DESCRIPTION
To avoid blocking when registering or unregistering a client id. This is
ok as informing the current connection holder of the client id is
already async. This should be more scalable and provide much better MQTT
connection setup latency.


Requires: https://github.com/rabbitmq/ra/pull/166