### PR TITLE
Maintenance mode event support

### DIFF
--- a/src/rabbit_mqtt.erl
+++ b/src/rabbit_mqtt.erl
@@ -38,11 +38,11 @@ start(normal, []) ->
 stop(_) ->
     rabbit_mqtt_sup:stop_listeners().
 
--spec close_all_client_connections(string() | binary()) -> {'ok', [{string(), pid()}]}.
+-spec close_all_client_connections(string() | binary()) -> {'ok', non_neg_integer()}.
 close_all_client_connections(Reason) ->
      Connections = rabbit_mqtt_collector:list(),
     [rabbit_mqtt_reader:close_connection(Pid, Reason) || {_, Pid} <- Connections],
-    {ok, Connections}.
+    {ok, length(Connections)}.
 
 emit_connection_info_all(Nodes, Items, Ref, AggregatorPid) ->
     Pids = [spawn_link(Node, rabbit_mqtt, emit_connection_info_local,

--- a/src/rabbit_mqtt.erl
+++ b/src/rabbit_mqtt.erl
@@ -34,8 +34,8 @@ start(normal, []) ->
     gen_event:add_handler(EMPid, rabbit_mqtt_vhost_event_handler, []),
     Result.
 
-stop(_State) ->
-    ok.
+stop(_) ->
+    rabbit_mqtt_sup:stop_listeners().
 
 emit_connection_info_all(Nodes, Items, Ref, AggregatorPid) ->
     Pids = [spawn_link(Node, rabbit_mqtt, emit_connection_info_local,

--- a/src/rabbit_mqtt.erl
+++ b/src/rabbit_mqtt.erl
@@ -20,7 +20,8 @@
 -export([start/2, stop/1]).
 -export([connection_info_local/1,
          emit_connection_info_local/3,
-         emit_connection_info_all/4]).
+         emit_connection_info_all/4,
+         close_all_client_connections/1]).
 
 start(normal, []) ->
     {ok, Listeners} = application:get_env(tcp_listeners),
@@ -31,11 +32,17 @@ start(normal, []) ->
               {ok, Pid}                       -> Pid;
               {error, {already_started, Pid}} -> Pid
             end,
-    gen_event:add_handler(EMPid, rabbit_mqtt_vhost_event_handler, []),
+    gen_event:add_handler(EMPid, rabbit_mqtt_internal_event_handler, []),
     Result.
 
 stop(_) ->
     rabbit_mqtt_sup:stop_listeners().
+
+-spec close_all_client_connections(string() | binary()) -> {'ok', [{string(), pid()}]}.
+close_all_client_connections(Reason) ->
+     Connections = rabbit_mqtt_collector:list(),
+    [rabbit_mqtt_reader:close_connection(Pid, Reason) || {_, Pid} <- Connections],
+    {ok, Connections}.
 
 emit_connection_info_all(Nodes, Items, Ref, AggregatorPid) ->
     Pids = [spawn_link(Node, rabbit_mqtt, emit_connection_info_local,

--- a/src/rabbit_mqtt_internal_event_handler.erl
+++ b/src/rabbit_mqtt_internal_event_handler.erl
@@ -36,7 +36,7 @@ handle_event({event, vhost_deleted, Info, _, _}, State) ->
 handle_event({event, maintenance_connections_closed, _Info, _, _}, State) ->
   %% we should close our  connections
   {ok, NConnections} = rabbit_mqtt:close_all_client_connections("Node is being put into maintenance mode"),
-  rabbit_log:alert("Closed ~b local MQTT client connections", [length(NConnections)]),
+  rabbit_log:alert("Closed ~b local MQTT client connections", [NConnections]),
   {ok, State};
 handle_event(_Event, State) ->
   {ok, State}.

--- a/src/rabbit_mqtt_internal_event_handler.erl
+++ b/src/rabbit_mqtt_internal_event_handler.erl
@@ -34,8 +34,8 @@ handle_event({event, vhost_deleted, Info, _, _}, State) ->
   rabbit_mqtt_retainer_sup:delete_child(Name),
   {ok, State};
 handle_event({event, maintenance_connections_closed, _Info, _, _}, State) ->
-  %% we should close our  connections
-  {ok, NConnections} = rabbit_mqtt:close_all_client_connections("Node is being put into maintenance mode"),
+  %% we should close our connections
+  {ok, NConnections} = rabbit_mqtt:close_all_client_connections("node is being put into maintenance mode"),
   rabbit_log:alert("Closed ~b local MQTT client connections", [NConnections]),
   {ok, State};
 handle_event(_Event, State) ->

--- a/src/rabbit_mqtt_internal_event_handler.erl
+++ b/src/rabbit_mqtt_internal_event_handler.erl
@@ -14,7 +14,7 @@
 %% Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
--module(rabbit_mqtt_vhost_event_handler).
+-module(rabbit_mqtt_internal_event_handler).
 
 -behaviour(gen_event).
 
@@ -32,6 +32,11 @@ handle_event({event, vhost_created, Info, _, _}, State) ->
 handle_event({event, vhost_deleted, Info, _, _}, State) ->
   Name = pget(name, Info),
   rabbit_mqtt_retainer_sup:delete_child(Name),
+  {ok, State};
+handle_event({event, maintenance_connections_closed, _Info, _, _}, State) ->
+  %% we should close our  connections
+  {ok, NConnections} = rabbit_mqtt:close_all_client_connections("Node is being put into maintenance mode"),
+  rabbit_log:alert("Closed ~b local MQTT client connections", [length(NConnections)]),
   {ok, State};
 handle_event(_Event, State) ->
   {ok, State}.

--- a/src/rabbit_mqtt_sup.erl
+++ b/src/rabbit_mqtt_sup.erl
@@ -61,14 +61,8 @@ init([{Listeners, SslListeners0}]) ->
                           [SocketOpts, SslOpts, NumSslAcceptors], SslListeners)]}}.
 
 stop_listeners() ->
-    case rabbit_networking:ranch_ref_of_protocol(?TCP_PROTOCOL) of
-        {error, not_found} -> ok;
-        Ref1               -> ranch:stop_listener(Ref1)
-    end,
-    case rabbit_networking:ranch_ref_of_protocol(?TLS_PROTOCOL) of
-        {error, not_found} -> ok;
-        Ref2               -> ranch:stop_listener(Ref2)
-    end,
+    rabbit_networking:stop_ranch_listener_of_protocol(?TCP_PROTOCOL),
+    rabbit_networking:stop_ranch_listener_of_protocol(?TLS_PROTOCOL),
     ok.
 
 %%


### PR DESCRIPTION
This makes the refs predictable and easy to compute
from a listener record. Then suspending all listeners
becomes a lot simpler.

While at it, make protocol applications clean up
their listeners when they stop. This way tests
and other callers that have to stop the app
would not need to know anything about
its listeners.

Part of rabbitmq/rabbitmq-server#2321